### PR TITLE
Feature: Accept string resources for the HTML or Markdown conversion to PDF routes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,3 +2,15 @@ codecov:
   require_ci_to_pass: true
 comment:
   require_changes: true
+coverage:
+  status:
+    project:
+      default:
+        # https://docs.codecov.com/docs/commit-status#threshold
+        threshold: 1%
+    patch:
+      default:
+        # For the changed lines only, target 90% covered, but
+        # allow as low as 80%
+        target: 90%
+        threshold: 10%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All routes now return a stronger typed response than just an `httpx.Response` ([#23](https://github.com/stumpylog/gotenberg-client/pull/23))
 - All public methods now include docstrings ([#33](https://github.com/stumpylog/gotenberg-client/pull/33))
+- The Chromium based HTML and Markdown to PDF routes can now accept accept a `str`, containing either HTML text, Markdown or other text based resources for conversion ([#30](https://github.com/stumpylog/gotenberg-client/pull/30))
+  - See `string_index`, `string_resource` and `string_resources` for those routes
 
 ### Changed
 

--- a/src/gotenberg_client/_convert/common.py
+++ b/src/gotenberg_client/_convert/common.py
@@ -145,11 +145,11 @@ class HeaderFooterMixin:
     """
 
     def header(self, header: Path) -> Self:
-        self._add_file_map(header, "header.html")  # type: ignore[attr-defined]
+        self._add_file_map(header, name="header.html")  # type: ignore[attr-defined]
         return self
 
     def footer(self, footer: Path) -> Self:
-        self._add_file_map(footer, "footer.html")  # type: ignore[attr-defined]
+        self._add_file_map(footer, name="footer.html")  # type: ignore[attr-defined]
         return self
 
 

--- a/src/gotenberg_client/_merge.py
+++ b/src/gotenberg_client/_merge.py
@@ -60,7 +60,7 @@ class MergeRoute(BaseZipFileResponseRoute):
         """
         for filepath in files:
             # Include index to enforce ordering
-            self._add_file_map(filepath, f"{self._next}_{filepath.name}")
+            self._add_file_map(filepath, name=f"{self._next}_{filepath.name}")
             self._next += 1
         return self
 

--- a/tests/test_convert_chromium_markdown.py
+++ b/tests/test_convert_chromium_markdown.py
@@ -31,3 +31,31 @@ class TestConvertChromiumUrlRoute:
         assert resp.status_code == codes.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
+
+    def test_basic_convert_string_references(
+        self,
+        client: GotenbergClient,
+        markdown_index_file: Path,
+        markdown_sample_one_file: Path,
+        markdown_sample_two_file: Path,
+        img_gif_file: Path,
+        font_file: Path,
+        css_style_file: Path,
+    ):
+        with client.chromium.markdown_to_pdf() as route:
+            resp = (
+                route.index(markdown_index_file)
+                .string_resources(
+                    [
+                        (markdown_sample_one_file.read_text(), "markdown1.md", "text/markdown"),
+                        (markdown_sample_two_file.read_text(), "markdown2.md", "text/markdown"),
+                    ],
+                )
+                .resources([img_gif_file, font_file])
+                .resource(css_style_file)
+                .run_with_retry()
+            )
+
+        assert resp.status_code == codes.OK
+        assert "Content-Type" in resp.headers
+        assert resp.headers["Content-Type"] == "application/pdf"


### PR DESCRIPTION
This now includes accepting strings for resources which can be strings, such as the `index.html` or other resource files referred to by the `index.html` or primary Markdown file, such as fonts or CSS.