### PR TITLE
Adds support for converting a single file from a memory buffer to PDF.

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -248,12 +248,12 @@ Some fields cannot be set or will be overwritten, depending on Gotenberg and its
 
 ### Office Documents to PDF
 
-| Gotenberg Link                                                                      | Route Access          | Required Properties                                                                            | Optional Properties                                       |
-| ----------------------------------------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [Documentation](https://gotenberg.dev/docs/routes#office-documents-into-pdfs-route) | `libre_office.to_pdf` | <ul><li>`.convert("mydoc.docx")`</li><li>or</li><li>`.convert_files(["mydoc.docx"])`</li></ul> | See [common LibreOffice options](#libreoffice-properties) |
+| Gotenberg Link                                                                      | Route Access          | Required Properties                                                                                                                                          | Optional Properties                                       |
+| ----------------------------------------------------------------------------------- | --------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------| --------------------------------------------------------- |
+| [Documentation](https://gotenberg.dev/docs/routes#office-documents-into-pdfs-route) | `libre_office.to_pdf` | <p>Any of:</p><ul><li>`.convert("mydoc.docx")`</li><li>`.convert_files(["mydoc.docx"])`</li><li>`.convert_in_memory_file(data, name="mydoc.docx")`</li></ul> | See [common LibreOffice options](#libreoffice-properties) |
 
 !!! note
-`convert` may be called multiple times" !!! note "`convert_files` is a convenience method to convert a list of file into PDF
+`convert` / `convert_in_memory_file` may be called multiple times" !!! note "`convert_files` is a convenience method to convert a list of files into PDF
 
 ### LibreOffice Properties
 

--- a/src/gotenberg_client/_base/routes.py
+++ b/src/gotenberg_client/_base/routes.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from time import sleep
 from types import TracebackType
 from typing import Any
+from typing import BinaryIO
 from typing import Generic
 from typing import Optional
 from typing import Union
@@ -68,7 +69,7 @@ class BaseRoute(ABC, Generic[ClientT]):
         # These are the names of files, mapping to their Path
         self._file_map: dict[str, Path] = {}
         # Additional in memory resources, mapping the referenced name to the content and an optional mimetype
-        self._in_memory_resources: dict[str, tuple[str, Optional[str]]] = {}
+        self._in_memory_resources: dict[str, tuple[Union[str, BinaryIO], Optional[str]]] = {}
         # Any header that will also be sent
         self._headers: dict[str, str] = {}
         self._next = 1
@@ -243,12 +244,12 @@ class BaseRoute(ABC, Generic[ClientT]):
 
         self._file_map[name] = filepath
 
-    def _add_in_memory_file(self, data: str, *, name: str, mime_type: Optional[str] = None) -> None:
+    def _add_in_memory_file(self, data: Union[str, BinaryIO], *, name: str, mime_type: Optional[str] = None) -> None:
         """
         Add an in-memory file to the resources to be uploaded.
 
         Args:
-            data (str): The content of the file.
+            data (str or BinaryIO): The content of the file.
             name (str): Name to use for the file in the request.
             mime_type (Optional[str], optional): MIME type of the file. Defaults to None.
         """

--- a/src/gotenberg_client/_libreoffice/routes.py
+++ b/src/gotenberg_client/_libreoffice/routes.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 from pathlib import Path
+from typing import BinaryIO
 from typing import Final
+from typing import Optional
 
 from gotenberg_client._base import AsyncBaseRoute
 from gotenberg_client._base import SyncBaseRoute
@@ -73,6 +75,21 @@ class _BaseOfficeDocumentToPdfRoute(
         """
         for x in file_paths:
             self.convert(x)
+        return self
+
+    def convert_in_memory_file(self, data: BinaryIO, *, name: str, mime_type: Optional[str] = None) -> Self:
+        """
+        Add single file from buffer for PDF conversion.
+
+        Args:
+            data (BinaryIO): The content of the file.
+            name (str): Name to use for the file in the request.
+            mime_type (Optional[str], optional): MIME type of the file. Defaults to None.
+
+        Returns:
+            LibreOfficeConvertRoute: This object itself for method chaining.
+        """
+        self._add_in_memory_file(data, name=name, mime_type=mime_type)  # type: ignore[attr-defined]
         return self
 
 

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 from http import HTTPStatus
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,6 +37,17 @@ class TestLibreOfficeConvert:
                 resp = route.convert(docx_sample_file).run()
             except:  # noqa: E722, pragma: no cover
                 return
+
+        assert resp.status_code == HTTPStatus.OK
+        assert "Content-Type" in resp.headers
+        assert resp.headers["Content-Type"] == "application/pdf"
+
+    def test_libre_office_convert_docx_format_in_memory(self, sync_client: GotenbergClient, docx_sample_file: Path):
+        with sync_client.libre_office.to_pdf() as route:
+            resp = route.convert_in_memory_file(
+                data=BytesIO(docx_sample_file.read_bytes()),
+                name=docx_sample_file.name,
+            ).run_with_retry()
 
         assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers


### PR DESCRIPTION
A very minimal solution to allow use of in-memory buffers for doing libreOffice pdf-conversions.

Didn't bother with the existing functions for mime-type guessing. (either httpx will infer it from the name or the user will have to guess it using magic)

OK to just re-use the in-memory stuff setup used for the chronium route? 