### PR TITLE
Fix Merge handling for >= 10 Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Allow for more than 10 Documents to be merged while keeping the sorting intact
+
 ## [0.13.0] - 2025-11-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Fixed
+
 - Allow for more than 10 Documents to be merged while keeping the sorting intact
 
 ## [0.13.0] - 2025-11-18

--- a/src/gotenberg_client/_merge/routes.py
+++ b/src/gotenberg_client/_merge/routes.py
@@ -49,7 +49,7 @@ class _BaseMergePdfFilesRoute(PdfFormatMixin, PfdUniversalAccessMixin, MetadataM
         """
         for filepath in files:
             # Include index to enforce ordering
-            self._add_file_map(filepath, name=f"{self._next}_{filepath.name}")  # type: ignore[attr-defined,misc]
+            self._add_file_map(filepath, name=f"{self._next:05d}_{filepath.name}")  # type: ignore[attr-defined,misc]
             self._next += 1  # type: ignore[attr-defined,misc]
         return self
 


### PR DESCRIPTION
Gotenberg sorts first by number and then by letters in the file "name".

The name is generated by a counter starting from 1,2,3,...,10,11,12,13. Resulting in names like: 

1_file, 2_file, 3_file...10_file,11_file,....

which then result in an merged order by gotenberg like this

1_file, 10_file, 11_file,... , 2_file, 20_file, ...

this pull requests adds leading zeros to allow for up to 5 digits of index to be handled correctly. I assume that will be enough for any sensible pdf merging needs. 