### PR TITLE
Feature: add cross-route PDF manipulation mixins (watermark, stamp, rotate and more)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it via `backend="requests"` on `SyncGotenbergClient`
     - `AsyncGotenbergClient` raises `ValueError` if `backend="requests"` is passed, since
       `requests` has no async support
+- Watermark support: apply a watermark behind page content on Chromium,
+  LibreOffice, Merge, and Split routes via `watermark_source()`, `watermark_expression()`,
+  `watermark_pages()`, `watermark_options()`, and `watermark_file()`
+- Stamp support: apply a stamp on top of page content on Chromium,
+  LibreOffice, Merge, and Split routes via `stamp_source()`, `stamp_expression()`,
+  `stamp_pages()`, `stamp_options()`, and `stamp_file()`
+- Rotate support: rotate PDF pages by 90°, 180°, or 270° on Chromium,
+  LibreOffice, Merge, and Split routes via `rotate(angle, pages=None)`
+- Encrypt support: password-protect output PDFs on Chromium,
+  LibreOffice, Merge, and Split routes via `user_password()` and `owner_password()`
+- Embed support: attach external files inside the PDF container on
+  Chromium, LibreOffice, Merge, and Split routes via `embed()` and `embed_files()`
+- Download-from support: instruct Gotenberg to fetch input files
+  from URLs rather than requiring direct uploads on Chromium, LibreOffice, Merge, and
+  Split routes via `download_from(urls)`
+- Flatten options now also applied to all Chromium conversion routes
+- New option types in `gotenberg_client.options`:
+    - `WatermarkStampSource` enum (`Text`, `Image`, `Pdf`)
+    - `RotateAngle` enum (`Clockwise90`, `Clockwise180`, `Clockwise270`)
+    - `WatermarkStampOptions` dataclass (font, points, color, rotation, opacity, scale)
+    - `DownloadFromUrl` dataclass (url, extra_http_headers, embedded, field)
 
 ### Changed
 
+- Internal `RequestFiles` type changed from `dict` to `list[tuple[str, FileEntry]]` to
+  preserve file ordering when multiple files are submitted in a single request
 - `run()` and `run_with_retry()` now raise `HttpStatusError` (from `gotenberg_client`)
   instead of `httpx.HTTPStatusError` for non-2xx responses
     - **Migration**: replace `except httpx.HTTPStatusError` with `except HttpStatusError`

--- a/docs/ref_options.md
+++ b/docs/ref_options.md
@@ -17,3 +17,21 @@
 
 ::: gotenberg_client.options.Measurement
     handler: python
+
+::: gotenberg_client.options.PdfAFormat
+    handler: python
+
+::: gotenberg_client.options.TrappedStatus
+    handler: python
+
+::: gotenberg_client.options.WatermarkStampSource
+    handler: python
+
+::: gotenberg_client.options.WatermarkStampOptions
+    handler: python
+
+::: gotenberg_client.options.RotateAngle
+    handler: python
+
+::: gotenberg_client.options.DownloadFromUrl
+    handler: python

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -258,6 +258,12 @@ Supported metadata fields:
 
     Some fields cannot be set or will be overwritten, depending on Gotenberg and its utilized PDF engine
 
+#### Flatten, Watermark, Stamp, Rotate, Encrypt, Embeds, Download From
+
+Chromium conversion routes also support flattening, watermarking, stamping, rotation,
+encryption, file embedding, and URL-based input. See the [Global Options](#global-options)
+section for details.
+
 ## LibreOffice
 
 ### Office Documents to PDF
@@ -357,6 +363,12 @@ See [PDF Metadata Support](#pdf-metadata-support) for the API interface.
 | ---------------- | ------------------- | ----------- | ------------ |
 | `flatten`        | `.flatten()`        | `bool`      | keyword only |
 
+#### Watermark, Stamp, Rotate, Encrypt, Embeds, Download From
+
+The LibreOffice route also supports watermarking, stamping, rotation, encryption, file
+embedding, and URL-based input. See the [Global Options](#global-options) section for
+details.
+
 ## Convert into PDF/A & PDF/UA
 
 [Gotenberg Documentation](https://gotenberg.dev/docs/routes#convert-into-pdfa--pdfua-route)
@@ -451,12 +463,18 @@ Required Properties:
 
 Optional Properties:
 
-| Gotenberg Option | Route Configuration                                                             | Python Type  | Notes                                             |
-| ---------------- | ------------------------------------------------------------------------------- | ------------ | ------------------------------------------------- |
-| `pdfa`           | `.pdf_format()`                                                                 | `PdfAFormat` |                                                   |
-| `pdfua`          | <ul><li>`.enable_universal_access()`<li>`.disable_universal_access()`</li></ul> | N/A          |                                                   |
-| `flatten`        | `.flatten()`                                                                    | `bool`       | keyword only                                      |
-| `metadata`       | `.metadata()`                                                                   | N/A          | See [PDF Metadata Support](#pdf-metadata-support) |
+| Gotenberg Option | Route Configuration                                                             | Python Type             | Notes                                             |
+| ---------------- | ------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------- |
+| `pdfa`           | `.pdf_format()`                                                                 | `PdfAFormat`            |                                                   |
+| `pdfua`          | <ul><li>`.enable_universal_access()`<li>`.disable_universal_access()`</li></ul> | N/A                     |                                                   |
+| `flatten`        | `.flatten()`                                                                    | `bool`                  | keyword only                                      |
+| `metadata`       | `.metadata()`                                                                   | N/A                     | See [PDF Metadata Support](#pdf-metadata-support) |
+| watermark        | See [Watermark](#watermark)                                                     | `WatermarkStampSource`  |                                                   |
+| stamp            | See [Stamp](#stamp)                                                             | `WatermarkStampSource`  |                                                   |
+| rotate           | `.rotate()`                                                                     | `RotateAngle`           |                                                   |
+| encrypt          | `.user_password()` / `.owner_password()`                                        | `str`                   |                                                   |
+| embeds           | `.embed()` / `.embed_files()`                                                   | `Path` / `list[Path]`   |                                                   |
+| downloadFrom     | `.download_from()`                                                              | `list[DownloadFromUrl]` |                                                   |
 
 ```python
 from gotenberg_client import GotenbergClient
@@ -494,6 +512,12 @@ Optional Properties:
 | `pdfua`          | <ul><li>`.enable_universal_access()`<li>`.disable_universal_access()`</li></ul> | N/A                             |                                                   |
 | `flatten`        | `.flatten()`                                                                    | `bool`                          | keyword only                                      |
 | `metadata`       | `.metadata()`                                                                   | N/A                             | See [PDF Metadata Support](#pdf-metadata-support) |
+| watermark        | See [Watermark](#watermark)                                                     | `WatermarkStampSource`          |                                                   |
+| stamp            | See [Stamp](#stamp)                                                             | `WatermarkStampSource`          |                                                   |
+| rotate           | `.rotate()`                                                                     | `RotateAngle`                   |                                                   |
+| encrypt          | `.user_password()` / `.owner_password()`                                        | `str`                           |                                                   |
+| embeds           | `.embed()` / `.embed_files()`                                                   | `Path` / `list[Path]`           |                                                   |
+| downloadFrom     | `.download_from()`                                                              | `list[DownloadFromUrl]`         |                                                   |
 
 ```python
 from gotenberg_client import GotenbergClient
@@ -587,6 +611,94 @@ with client.chromium.html_to_pdf() as route:
 
 ### Download From
 
-!!! warning
+[Gotenberg Documentation](https://gotenberg.dev/docs/webhook-download)
 
-    This feature is not implemented
+Instruct Gotenberg to fetch input files from URLs instead of requiring direct uploads.
+Available on Chromium, LibreOffice, Merge, and Split routes.
+
+```python
+from gotenberg_client import GotenbergClient
+from gotenberg_client.options import DownloadFromUrl
+from pathlib import Path
+
+with GotenbergClient("http://localhost:3000") as client:
+    with client.chromium.url_to_pdf() as route:
+        response = route.download_from([
+            DownloadFromUrl(url="https://example.com/my.html"),
+        ]).run()
+        response.to_file(Path("output.pdf"))
+```
+
+`DownloadFromUrl` fields:
+
+| Field                | Type                     | Notes                                            |
+| -------------------- | ------------------------ | ------------------------------------------------ |
+| `url`                | `str`                    | Required                                         |
+| `extra_http_headers` | `dict[str, str] \| None` | Additional request headers                       |
+| `embedded`           | `bool`                   | Embed the file in the request (default: `False`) |
+| `field`              | `str \| None`            | Override the form field name                     |
+
+### Watermark
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/manipulate-pdfs/watermark-pdfs)
+
+Apply a watermark behind the content of each page. Available on Chromium, LibreOffice,
+Merge, and Split routes.
+
+| Route Method              | Python Type             | Notes                                                                |
+| ------------------------- | ----------------------- | -------------------------------------------------------------------- |
+| `.watermark_source()`     | `WatermarkStampSource`  | `Text`, `Image`, or `Pdf`                                            |
+| `.watermark_expression()` | `str`                   | Text string or expression (when source is `Text`)                    |
+| `.watermark_pages()`      | `str`                   | Page range (e.g. `"1-3"`)                                            |
+| `.watermark_options()`    | `WatermarkStampOptions` | Font, size, color, rotation, opacity, scale                          |
+| `.watermark_file()`       | `Path`                  | Image or PDF file to use as watermark (when source is `Image`/`Pdf`) |
+
+### Stamp
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/manipulate-pdfs/stamp-pdfs)
+
+Apply a stamp on top of the content of each page. Available on Chromium, LibreOffice,
+Merge, and Split routes. Uses the same option types as Watermark.
+
+| Route Method          | Python Type             | Notes                                             |
+| --------------------- | ----------------------- | ------------------------------------------------- |
+| `.stamp_source()`     | `WatermarkStampSource`  | `Text`, `Image`, or `Pdf`                         |
+| `.stamp_expression()` | `str`                   | Text string or expression (when source is `Text`) |
+| `.stamp_pages()`      | `str`                   | Page range (e.g. `"1-3"`)                         |
+| `.stamp_options()`    | `WatermarkStampOptions` | Font, size, color, rotation, opacity, scale       |
+| `.stamp_file()`       | `Path`                  | Image or PDF file to use as stamp                 |
+
+### Rotate
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs)
+
+Rotate PDF pages. Available on Chromium, LibreOffice, Merge, and Split routes.
+
+| Route Method | Python Type   | Notes                                         |
+| ------------ | ------------- | --------------------------------------------- |
+| `.rotate()`  | `RotateAngle` | `Clockwise90`, `Clockwise180`, `Clockwise270` |
+
+An optional `pages` string argument limits rotation to specific pages (e.g. `"1-3"`).
+
+### Encrypt
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/manipulate-pdfs/encrypt-pdfs)
+
+Password-protect the output PDF. Available on Chromium, LibreOffice, Merge, and Split routes.
+
+| Route Method        | Python Type | Notes                        |
+| ------------------- | ----------- | ---------------------------- |
+| `.user_password()`  | `str`       | User (open) password         |
+| `.owner_password()` | `str`       | Owner (permissions) password |
+
+### Embeds
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/manipulate-pdfs/attachments)
+
+Attach external files as embedded attachments inside the PDF container. Available on
+Chromium, LibreOffice, Merge, and Split routes.
+
+| Route Method     | Python Type  | Notes                                   |
+| ---------------- | ------------ | --------------------------------------- |
+| `.embed()`       | `Path`       | Attach a single file                    |
+| `.embed_files()` | `list[Path]` | Convenience method to attach many files |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,11 @@ plugins:
             show_root_heading: true
             show_root_full_path: true
             show_object_full_path: false
+            filters:
+              - "!^_"
+              - "!^to_form"
+              - "!^to_json"
+              - "!^asdict"
           inventories:
             - https://docs.python.org/3/objects.inv
 extra:

--- a/src/gotenberg_client/_base/routes.py
+++ b/src/gotenberg_client/_base/routes.py
@@ -71,6 +71,8 @@ class BaseRoute(ABC, Generic[ClientT]):
         self._headers: dict[str, str] = {}
         # Used to enforce ordering during merge operations
         self._next = 1
+        # Embed files as repeated form fields (field_name, file_path)
+        self._embed_files: list[tuple[str, Path]] = []
 
     @abstractmethod
     def _post_data(self) -> ResponseProtocol | Coroutine[Any, Any, ResponseProtocol]:
@@ -180,6 +182,7 @@ class BaseRoute(ABC, Generic[ClientT]):
         self._stack.close()
         self._form_data.clear()
         self._file_map.clear()
+        self._embed_files.clear()
         self._headers.pop("Gotenberg-Output-Filename", None)
         self._headers.pop("Gotenberg-Trace", None)
 
@@ -200,28 +203,39 @@ class BaseRoute(ABC, Generic[ClientT]):
         in-memory resources.
 
         Returns:
-            RequestFiles: A dictionary suitable for use as the 'files' parameter
-                in HTTP request methods.
+            RequestFiles: A list of (field_name, file_entry) tuples suitable for use
+                as the 'files' parameter in HTTP request methods. The list format allows
+                multiple entries with the same field name (e.g. for embeds).
         """
-        resources: RequestFiles = {}
-        for filename in self._file_map:
-            file_path = self._file_map[filename]
-
-            # Helpful but not necessary to provide the mime type when possible
+        resources: RequestFiles = []
+        for filename, file_path in self._file_map.items():
             mime_type = guess_mime_type(file_path)
             if mime_type is not None:
-                resources.update(
-                    {filename: (filename, self._stack.enter_context(file_path.open("rb")), mime_type)},
+                resources.append(
+                    (filename, (filename, self._stack.enter_context(file_path.open("rb")), mime_type)),
                 )
             else:  # pragma: no cover
-                resources.update({filename: (filename, self._stack.enter_context(file_path.open("rb")))})
+                resources.append(
+                    (filename, (filename, self._stack.enter_context(file_path.open("rb")))),
+                )
 
-        for resource_name in self._in_memory_resources:
-            data, mime_type = self._in_memory_resources[resource_name]
+        for resource_name, (data, mime_type) in self._in_memory_resources.items():
             if mime_type is not None:
-                resources.update({resource_name: (resource_name, data, mime_type)})
+                resources.append((resource_name, (resource_name, data, mime_type)))
             else:
-                resources.update({resource_name: (resource_name, data)})
+                resources.append((resource_name, (resource_name, data)))
+
+        for field_name, file_path in self._embed_files:
+            embed_filename = file_path.name
+            mime_type = guess_mime_type(file_path)
+            if mime_type is not None:
+                resources.append(
+                    (field_name, (embed_filename, self._stack.enter_context(file_path.open("rb")), mime_type)),
+                )
+            else:  # pragma: no cover
+                resources.append(
+                    (field_name, (embed_filename, self._stack.enter_context(file_path.open("rb")))),
+                )
 
         return resources
 

--- a/src/gotenberg_client/_chromium/routes.py
+++ b/src/gotenberg_client/_chromium/routes.py
@@ -26,13 +26,19 @@ from gotenberg_client._chromium.mixins import RenderControlMixin
 from gotenberg_client._chromium.mixins import ScaleMixin
 from gotenberg_client._chromium.mixins import ScreenShotSettingsMixin
 from gotenberg_client._chromium.mixins import SinglePageMixin
+from gotenberg_client._common import DownloadFromMixin
+from gotenberg_client._common import EmbedsMixin
+from gotenberg_client._common import EncryptMixin
+from gotenberg_client._common import FlattenOptionMixin
 from gotenberg_client._common import MetadataMixin
 from gotenberg_client._common import PdfFormatMixin
 from gotenberg_client._common import PdfUniversalAccessMixin
+from gotenberg_client._common import RotateMixin
 from gotenberg_client._common import SplitModeMixin
+from gotenberg_client._common import StampMixin
+from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._typing_compat import Self
-from gotenberg_client._utils import FORCE_MULTIPART
-from gotenberg_client._utils import ForceMultipartDict
+from gotenberg_client._utils import ForceMultipartList
 
 
 class _BaseChromiumConvertMixin(
@@ -59,6 +65,13 @@ class _BaseChromiumConvertMixin(
     PdfFormatMixin,
     PdfUniversalAccessMixin,
     MetadataMixin,
+    WatermarkMixin,
+    StampMixin,
+    RotateMixin,
+    EncryptMixin,
+    EmbedsMixin,
+    FlattenOptionMixin,
+    DownloadFromMixin,
 ):
     """
     Common form fields for Chromium-based PDF conversion routes.
@@ -210,14 +223,15 @@ class _BaseUrlFormMixin:
         self._form_data["url"] = url  # type: ignore[attr-defined,misc]
         return self
 
-    def _get_all_resources(self) -> ForceMultipartDict:
+    def _get_all_resources(self) -> ForceMultipartList:
         """
-        Returns an empty ForceMultipartDict.
+        Returns a ForceMultipartList containing any embed files from the parent.
 
-        This route does not require any file uploads, so an empty dictionary
-        is returned as Gotenberg still requires multipart/form-data
+        This route does not require any file uploads, so an empty list
+        is returned as Gotenberg still requires multipart/form-data.
+        When embed files have been added, they are included from the parent.
         """
-        return FORCE_MULTIPART
+        return ForceMultipartList(super()._get_all_resources())  # type: ignore[misc]
 
 
 class _BaseUrlToPdfChromiumConvertRoute(_BaseUrlFormMixin, _BaseChromiumConvertMixin):

--- a/src/gotenberg_client/_common/__init__.py
+++ b/src/gotenberg_client/_common/__init__.py
@@ -9,22 +9,34 @@ if TYPE_CHECKING:
     from gotenberg_client._http_backends._protocols import AsyncClientProtocol
     from gotenberg_client._http_backends._protocols import SyncClientProtocol
 
+from gotenberg_client._common.mixins import DownloadFromMixin
+from gotenberg_client._common.mixins import EmbedsMixin
+from gotenberg_client._common.mixins import EncryptMixin
 from gotenberg_client._common.mixins import FlattenOptionMixin
 from gotenberg_client._common.mixins import MetadataMixin
 from gotenberg_client._common.mixins import PdfAFormat
 from gotenberg_client._common.mixins import PdfFormatMixin
 from gotenberg_client._common.mixins import PdfUniversalAccessMixin
+from gotenberg_client._common.mixins import RotateMixin
 from gotenberg_client._common.mixins import SplitModeMixin
+from gotenberg_client._common.mixins import StampMixin
+from gotenberg_client._common.mixins import WatermarkMixin
 
 ClientT = TypeVar("ClientT", bound="SyncClientProtocol | AsyncClientProtocol")
 
 
 __all__ = [
     "ClientT",
+    "DownloadFromMixin",
+    "EmbedsMixin",
+    "EncryptMixin",
     "FlattenOptionMixin",
     "MetadataMixin",
     "PdfAFormat",
     "PdfFormatMixin",
     "PdfUniversalAccessMixin",
+    "RotateMixin",
     "SplitModeMixin",
+    "StampMixin",
+    "WatermarkMixin",
 ]

--- a/src/gotenberg_client/_common/mixins.py
+++ b/src/gotenberg_client/_common/mixins.py
@@ -4,6 +4,7 @@
 
 import json
 from datetime import datetime
+from pathlib import Path
 from typing import Final
 from typing import Literal
 
@@ -11,8 +12,12 @@ from gotenberg_client._errors import InvalidKeywordError
 from gotenberg_client._errors import InvalidPdfRevisionError
 from gotenberg_client._typing_compat import Self
 from gotenberg_client._utils import bool_to_form
+from gotenberg_client.options import DownloadFromUrl
 from gotenberg_client.options import PdfAFormat
+from gotenberg_client.options import RotateAngle
 from gotenberg_client.options import TrappedStatus
+from gotenberg_client.options import WatermarkStampOptions
+from gotenberg_client.options import WatermarkStampSource
 
 
 class PdfFormatMixin:
@@ -274,4 +279,114 @@ class FlattenOptionMixin:
             Self: The instance with the updated form data.
         """
         self._form_data.update(bool_to_form("flatten", flatten))  # type: ignore[attr-defined,misc]
+        return self
+
+
+class WatermarkMixin:
+    """
+    https://gotenberg.dev/docs/manipulate-pdfs/watermark-pdfs
+    Applies a watermark behind the content of each page.
+    """
+
+    def watermark_source(self, source: WatermarkStampSource) -> Self:
+        self._form_data.update({"watermarkSource": source.value})  # type: ignore[attr-defined,misc]
+        return self
+
+    def watermark_expression(self, expression: str) -> Self:
+        self._form_data.update({"watermarkExpression": expression})  # type: ignore[attr-defined,misc]
+        return self
+
+    def watermark_pages(self, pages: str) -> Self:
+        self._form_data.update({"watermarkPages": pages})  # type: ignore[attr-defined,misc]
+        return self
+
+    def watermark_options(self, options: WatermarkStampOptions) -> Self:
+        self._form_data.update({"watermarkOptions": options.to_json()})  # type: ignore[attr-defined,misc]
+        return self
+
+    def watermark_file(self, file_path: Path) -> Self:
+        self._add_file_map(file_path, name="watermark")  # type: ignore[attr-defined]
+        return self
+
+
+class StampMixin:
+    """
+    https://gotenberg.dev/docs/manipulate-pdfs/stamp-pdfs
+    Adds a stamp on top of the content of each page.
+    """
+
+    def stamp_source(self, source: WatermarkStampSource) -> Self:
+        self._form_data.update({"stampSource": source.value})  # type: ignore[attr-defined,misc]
+        return self
+
+    def stamp_expression(self, expression: str) -> Self:
+        self._form_data.update({"stampExpression": expression})  # type: ignore[attr-defined,misc]
+        return self
+
+    def stamp_pages(self, pages: str) -> Self:
+        self._form_data.update({"stampPages": pages})  # type: ignore[attr-defined,misc]
+        return self
+
+    def stamp_options(self, options: WatermarkStampOptions) -> Self:
+        self._form_data.update({"stampOptions": options.to_json()})  # type: ignore[attr-defined,misc]
+        return self
+
+    def stamp_file(self, file_path: Path) -> Self:
+        self._add_file_map(file_path, name="stamp")  # type: ignore[attr-defined]
+        return self
+
+
+class RotateMixin:
+    """
+    https://gotenberg.dev/docs/manipulate-pdfs/rotate-pdfs
+    Rotates pages by a given angle.
+    """
+
+    def rotate(self, angle: RotateAngle, pages: str | None = None) -> Self:
+        self._form_data.update({"rotateAngle": angle.value})  # type: ignore[attr-defined,misc]
+        if pages is not None:
+            self._form_data.update({"rotatePages": pages})  # type: ignore[attr-defined,misc]
+        return self
+
+
+class EncryptMixin:
+    """
+    https://gotenberg.dev/docs/manipulate-pdfs/encrypt-pdfs
+    Encrypts the output PDF with user and/or owner passwords.
+    """
+
+    def user_password(self, password: str) -> Self:
+        self._form_data.update({"userPassword": password})  # type: ignore[attr-defined,misc]
+        return self
+
+    def owner_password(self, password: str) -> Self:
+        self._form_data.update({"ownerPassword": password})  # type: ignore[attr-defined,misc]
+        return self
+
+
+class EmbedsMixin:
+    """
+    https://gotenberg.dev/docs/manipulate-pdfs/attachments
+    Embeds external files as attachments inside the PDF container.
+    """
+
+    def embed(self, file_path: Path) -> Self:
+        self._embed_files.append(("embeds", file_path))  # type: ignore[attr-defined,misc]
+        return self
+
+    def embed_files(self, file_paths: list[Path]) -> Self:
+        for fp in file_paths:
+            self.embed(fp)
+        return self
+
+
+class DownloadFromMixin:
+    """
+    Instructs Gotenberg to fetch files from URLs rather than requiring uploads.
+    https://gotenberg.dev/docs/webhook-download
+    """
+
+    def download_from(self, urls: list[DownloadFromUrl]) -> Self:
+        data = json.dumps([u.asdict() for u in urls])  # type: ignore[misc]
+        self._form_data.update({"downloadFrom": data})  # type: ignore[attr-defined,misc]
         return self

--- a/src/gotenberg_client/_http_backends/_protocols.py
+++ b/src/gotenberg_client/_http_backends/_protocols.py
@@ -14,7 +14,8 @@ AuthType = tuple[str, str] | None
 _FileContent = bytes | str | BinaryIO
 _FileEntryWithMime = tuple[str, _FileContent, str]
 _FileEntryWithoutMime = tuple[str, _FileContent]
-RequestFiles = dict[str, "_FileEntryWithMime | _FileEntryWithoutMime"]
+_FileEntry = _FileEntryWithMime | _FileEntryWithoutMime
+RequestFiles = list[tuple[str, _FileEntry]]
 
 
 class ResponseProtocol(Protocol):  # no cov

--- a/src/gotenberg_client/_libreoffice/routes.py
+++ b/src/gotenberg_client/_libreoffice/routes.py
@@ -7,11 +7,17 @@ from typing import Final
 
 from gotenberg_client._base import AsyncBaseRoute
 from gotenberg_client._base import SyncBaseRoute
+from gotenberg_client._common import DownloadFromMixin
+from gotenberg_client._common import EmbedsMixin
+from gotenberg_client._common import EncryptMixin
 from gotenberg_client._common import FlattenOptionMixin
 from gotenberg_client._common import MetadataMixin
 from gotenberg_client._common import PdfFormatMixin
 from gotenberg_client._common import PdfUniversalAccessMixin
+from gotenberg_client._common import RotateMixin
 from gotenberg_client._common import SplitModeMixin
+from gotenberg_client._common import StampMixin
+from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeCompressOptionsMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeMergeOptionMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficePagePropertiesMixin
@@ -27,6 +33,12 @@ class _BaseOfficeDocumentToPdfRoute(
     PdfUniversalAccessMixin,
     MetadataMixin,
     FlattenOptionMixin,
+    WatermarkMixin,
+    StampMixin,
+    RotateMixin,
+    EncryptMixin,
+    EmbedsMixin,
+    DownloadFromMixin,
 ):
     """
 

--- a/src/gotenberg_client/_merge/routes.py
+++ b/src/gotenberg_client/_merge/routes.py
@@ -6,14 +6,31 @@ from typing import Final
 
 from gotenberg_client._base import AsyncBaseRoute
 from gotenberg_client._base import SyncBaseRoute
+from gotenberg_client._common import DownloadFromMixin
+from gotenberg_client._common import EmbedsMixin
+from gotenberg_client._common import EncryptMixin
 from gotenberg_client._common import FlattenOptionMixin
 from gotenberg_client._common import MetadataMixin
 from gotenberg_client._common import PdfFormatMixin
 from gotenberg_client._common import PdfUniversalAccessMixin
+from gotenberg_client._common import RotateMixin
+from gotenberg_client._common import StampMixin
+from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._typing_compat import Self
 
 
-class _BaseMergePdfFilesRoute(PdfFormatMixin, PdfUniversalAccessMixin, MetadataMixin, FlattenOptionMixin):
+class _BaseMergePdfFilesRoute(
+    PdfFormatMixin,
+    PdfUniversalAccessMixin,
+    MetadataMixin,
+    FlattenOptionMixin,
+    WatermarkMixin,
+    StampMixin,
+    RotateMixin,
+    EncryptMixin,
+    EmbedsMixin,
+    DownloadFromMixin,
+):
     """
     Represents the Gotenberg route for converting PDFs to PDF/A format.
 

--- a/src/gotenberg_client/_others/routes.py
+++ b/src/gotenberg_client/_others/routes.py
@@ -6,15 +6,33 @@ from typing import Final
 
 from gotenberg_client._base import AsyncBaseRoute
 from gotenberg_client._base import SyncBaseRoute
+from gotenberg_client._common import DownloadFromMixin
+from gotenberg_client._common import EmbedsMixin
+from gotenberg_client._common import EncryptMixin
 from gotenberg_client._common import FlattenOptionMixin
 from gotenberg_client._common import MetadataMixin
 from gotenberg_client._common import PdfFormatMixin
 from gotenberg_client._common import PdfUniversalAccessMixin
+from gotenberg_client._common import RotateMixin
 from gotenberg_client._common import SplitModeMixin
+from gotenberg_client._common import StampMixin
+from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._typing_compat import Self
 
 
-class _BaseSplitRoute(PdfFormatMixin, PdfUniversalAccessMixin, SplitModeMixin, MetadataMixin, FlattenOptionMixin):
+class _BaseSplitRoute(
+    PdfFormatMixin,
+    PdfUniversalAccessMixin,
+    SplitModeMixin,
+    MetadataMixin,
+    FlattenOptionMixin,
+    WatermarkMixin,
+    StampMixin,
+    RotateMixin,
+    EncryptMixin,
+    EmbedsMixin,
+    DownloadFromMixin,
+):
     """
     https://gotenberg.dev/docs/routes#split-pdfs-route
     """

--- a/src/gotenberg_client/_utils.py
+++ b/src/gotenberg_client/_utils.py
@@ -7,7 +7,7 @@ from typing import Final
 
 
 # See https://github.com/psf/requests/issues/1081#issuecomment-428504128
-class ForceMultipartDict(dict):
+class ForceMultipartList(list):
     def __bool__(self) -> bool:
         return True
 
@@ -82,4 +82,4 @@ def guess_mime_type_magic(url: str | Path) -> str | None:
 # Use the best option
 guess_mime_type = guess_mime_type_magic if find_spec("magic") is not None else guess_mime_type_stdlib
 
-FORCE_MULTIPART: Final = ForceMultipartDict()
+FORCE_MULTIPART: Final = ForceMultipartList()

--- a/src/gotenberg_client/options.py
+++ b/src/gotenberg_client/options.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import dataclasses
 import enum
+import json
 from typing import Final
 from typing import Literal
 
@@ -14,7 +15,18 @@ from gotenberg_client._utils import optional_to_form
 @dataclasses.dataclass(slots=True)
 class CookieJar:
     """
-    https://gotenberg.dev/docs/routes#cookies-chromium
+    A cookie to send with Chromium requests.
+
+    See https://gotenberg.dev/docs/routes#cookies-chromium
+
+    Attributes:
+        name (str): The cookie name.
+        value (str): The cookie value.
+        domain (str): The domain the cookie applies to.
+        path (str | None): The URL path the cookie applies to.
+        secure (bool | None): Whether the cookie is only sent over HTTPS.
+        http_only (bool | None): Whether the cookie is inaccessible to JavaScript.
+        same_site (str | None): SameSite policy — ``"Strict"``, ``"Lax"``, or ``"None"``.
     """
 
     name: str
@@ -73,7 +85,7 @@ class Measurement:
 
     Attributes:
         value (float or int): The numerical value of the measurement.
-        unit (UnitType): The unit of measurement for the measurement.
+        unit (MeasurementUnitType): The unit of measurement for the measurement.
     """
 
     value: float | int
@@ -105,6 +117,12 @@ class PdfAFormat(enum.Enum):
       - https://gotenberg.dev/docs/routes#pdfa-libreoffice
       - https://gotenberg.dev/docs/routes#convert-into-pdfa--pdfua-route
       - https://gotenberg.dev/docs/routes#merge-pdfs-route
+
+    Attributes:
+        A1a: PDF/A-1a (deprecated).
+        A1b: PDF/A-1b.
+        A2b: PDF/A-2b.
+        A3b: PDF/A-3b.
     """
 
     A1a = enum.auto()
@@ -147,6 +165,10 @@ class PdfAFormat(enum.Enum):
 class PageOrientation(enum.Enum):
     """
     Represents the possible orientations for a page in Gotenberg.
+
+    Attributes:
+        Landscape: Horizontal page orientation.
+        Portrait: Vertical page orientation.
     """
 
     Landscape = enum.auto()
@@ -235,8 +257,117 @@ class PageMarginsType:
 
 @enum.unique
 class TrappedStatus(StrEnum):
-    """Enum for valid trapped status values."""
+    """
+    Valid values for the PDF ``Trapped`` metadata key.
+
+    Attributes:
+        TRUE: Trapping has been applied to the document.
+        FALSE: Trapping has not been applied.
+        UNKNOWN: Trapping status is unknown.
+    """
 
     TRUE = "True"
     FALSE = "False"
     UNKNOWN = "Unknown"
+
+
+@enum.unique
+class WatermarkStampSource(str, enum.Enum):
+    """
+    Source type for watermark or stamp content.
+
+    Attributes:
+        Text: Watermark/stamp content is plain text.
+        Image: Watermark/stamp content is an image file.
+        Pdf: Watermark/stamp content is a PDF file.
+    """
+
+    Text = "text"
+    Image = "image"
+    Pdf = "pdf"
+
+
+@enum.unique
+class RotateAngle(str, enum.Enum):
+    """
+    Valid rotation angles in degrees.
+
+    Attributes:
+        Clockwise90: Rotate 90 degrees clockwise.
+        Clockwise180: Rotate 180 degrees.
+        Clockwise270: Rotate 270 degrees clockwise (90 degrees counter-clockwise).
+    """
+
+    Clockwise90 = "90"
+    Clockwise180 = "180"
+    Clockwise270 = "270"
+
+
+@dataclasses.dataclass(slots=True)
+class WatermarkStampOptions:
+    """
+    Advanced options for watermark/stamp rendering.
+    Field names and semantics depend on the configured PDF engine (pdfcpu by default).
+    See https://gotenberg.dev/docs/manipulate-pdfs/watermark-pdfs for details.
+
+    Attributes:
+        font (str | None): Font name for text watermarks/stamps.
+        points (int | None): Font size in points.
+        color (str | None): Font color as a hex string (e.g. ``"#FF0000"``).
+        rotation (int | None): Rotation angle in degrees.
+        opacity (float | None): Opacity between 0.0 (transparent) and 1.0 (opaque).
+        scale (float | None): Scale factor relative to the page size.
+    """
+
+    font: str | None = None
+    points: int | None = None
+    color: str | None = None
+    rotation: int | None = None
+    opacity: float | None = None
+    scale: float | None = None
+
+    def to_json(self) -> str:
+        data: dict[str, str | int | float] = {}
+        if self.font is not None:
+            data["font"] = self.font
+        if self.points is not None:
+            data["points"] = self.points
+        if self.color is not None:
+            data["color"] = self.color
+        if self.rotation is not None:
+            data["rotation"] = self.rotation
+        if self.opacity is not None:
+            data["opacity"] = self.opacity
+        if self.scale is not None:
+            data["scale"] = self.scale
+        return json.dumps(data)
+
+
+@dataclasses.dataclass(slots=True)
+class DownloadFromUrl:
+    """
+    Instructs Gotenberg to fetch a file from a URL instead of a direct upload.
+    See https://gotenberg.dev/docs/webhook-download for details.
+
+    Attributes:
+        url (str): URL of the file. The remote server must return a ``Content-Disposition``
+            header with a ``filename`` parameter.
+        extra_http_headers (dict[str, str] | None): Extra HTTP headers to send when fetching
+            this URL.
+        embedded (bool): Whether to embed the file (legacy; prefer ``field``).
+        field (str | None): Routes the downloaded file to a specific form field: ``"embedded"``,
+            ``"watermark"``, or ``"stamp"``. Takes precedence over ``embedded`` when set.
+    """
+
+    url: str
+    extra_http_headers: dict[str, str] | None = None
+    embedded: bool = False
+    field: str | None = None
+
+    def asdict(self) -> dict[str, str | bool | dict[str, str]]:
+        data: dict[str, str | bool | dict[str, str]] = {"url": self.url, "embedded": self.embedded}
+        if self.extra_http_headers:
+            data["extraHttpHeaders"] = self.extra_http_headers
+        if self.field is not None:
+            data["field"] = self.field
+        return data

--- a/tests/test_backend_niquests.py
+++ b/tests/test_backend_niquests.py
@@ -32,6 +32,7 @@ async def async_niquests_client(gotenberg_host: str) -> AsyncGenerator[AsyncGote
 
 
 class TestNiquestsBackendSync:
+    @pytest.mark.flaky(reruns=3)
     def test_health_check(self, sync_niquests_client: SyncGotenbergClient):
         with sync_niquests_client.health as api:
             status = api.health()

--- a/tests/test_common_mixins.py
+++ b/tests/test_common_mixins.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2025-present Trenton H <rda0128ou@mozmail.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+
+from gotenberg_client import GotenbergClient
+from gotenberg_client.options import DownloadFromUrl
+from gotenberg_client.options import RotateAngle
+from gotenberg_client.options import WatermarkStampSource
+from tests.utils import verify_stream_contains
+
+
+class TestWatermarkMixin:
+    def test_watermark_text_source(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_source(WatermarkStampSource.Text).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkSource", "text")
+
+    def test_watermark_expression(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_expression("DRAFT").run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkExpression", "DRAFT")
+
+    def test_watermark_pages(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_pages("1-3").run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkPages", "1-3")
+
+
+class TestStampMixin:
+    def test_stamp_text_source(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_source(WatermarkStampSource.Text).run()
+        verify_stream_contains(httpx_mock.get_request(), "stampSource", "text")
+
+    def test_stamp_expression(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_expression("CONFIDENTIAL").run()
+        verify_stream_contains(httpx_mock.get_request(), "stampExpression", "CONFIDENTIAL")
+
+
+class TestRotateMixin:
+    def test_rotate_angle(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).rotate(RotateAngle.Clockwise90).run()
+        verify_stream_contains(httpx_mock.get_request(), "rotateAngle", "90")
+
+    def test_rotate_pages(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).rotate(RotateAngle.Clockwise180, pages="2-4").run()
+        verify_stream_contains(httpx_mock.get_request(), "rotateAngle", "180")
+        verify_stream_contains(httpx_mock.get_request(), "rotatePages", "2-4")
+
+
+class TestEncryptMixin:
+    def test_user_password(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).user_password("secret").run()
+        verify_stream_contains(httpx_mock.get_request(), "userPassword", "secret")
+
+    def test_owner_password(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).owner_password("admin").run()
+        verify_stream_contains(httpx_mock.get_request(), "ownerPassword", "admin")
+
+
+class TestEmbedsMixin:
+    def test_single_embed(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+        sample_directory: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).embed(sample_directory / "sample1.pdf").run()
+        # Verify a part with name="embeds" exists in the multipart request
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        assert any(b'name="embeds"' in part for part in parts), "No embeds field found in request"
+
+    def test_multiple_embeds(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+        sample_directory: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).embed_files(
+                [
+                    sample_directory / "sample1.pdf",
+                    sample_directory / "sample1.pdf",
+                ],
+            ).run()
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        embeds_parts = [p for p in parts if b'name="embeds"' in p]
+        assert len(embeds_parts) == 2, f"Expected 2 embeds parts, got {len(embeds_parts)}"
+
+
+class TestDownloadFromMixin:
+    def test_download_from(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).download_from(
+                [
+                    DownloadFromUrl(url="http://example.com/file.pdf"),
+                ],
+            ).run()
+        verify_stream_contains(httpx_mock.get_request(), "downloadFrom", "http://example.com/file.pdf")

--- a/tests/test_common_mixins.py
+++ b/tests/test_common_mixins.py
@@ -9,6 +9,7 @@ from pytest_httpx import HTTPXMock
 from gotenberg_client import GotenbergClient
 from gotenberg_client.options import DownloadFromUrl
 from gotenberg_client.options import RotateAngle
+from gotenberg_client.options import WatermarkStampOptions
 from gotenberg_client.options import WatermarkStampSource
 from tests.utils import verify_stream_contains
 
@@ -47,6 +48,32 @@ class TestWatermarkMixin:
             route.url(webserver_docker_internal_url).watermark_pages("1-3").run()
         verify_stream_contains(httpx_mock.get_request(), "watermarkPages", "1-3")
 
+    def test_watermark_options(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_options(WatermarkStampOptions(font="Arial")).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkOptions", "Arial")
+
+    def test_watermark_file(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+        sample_directory: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_file(sample_directory / "sample1.pdf").run()
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        assert any(b'name="watermark"' in part for part in parts)
+
 
 class TestStampMixin:
     def test_stamp_text_source(
@@ -70,6 +97,43 @@ class TestStampMixin:
         with sync_client.chromium.url_to_pdf() as route:
             route.url(webserver_docker_internal_url).stamp_expression("CONFIDENTIAL").run()
         verify_stream_contains(httpx_mock.get_request(), "stampExpression", "CONFIDENTIAL")
+
+    def test_stamp_pages(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_pages("2-4").run()
+        verify_stream_contains(httpx_mock.get_request(), "stampPages", "2-4")
+
+    def test_stamp_options(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_options(WatermarkStampOptions(color="#FF0000")).run()
+        verify_stream_contains(httpx_mock.get_request(), "stampOptions", "#FF0000")
+
+    def test_stamp_file(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+        sample_directory: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_file(sample_directory / "sample1.pdf").run()
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        assert any(b'name="stamp"' in part for part in parts)
 
 
 class TestRotateMixin:
@@ -176,3 +240,36 @@ class TestDownloadFromMixin:
                 ],
             ).run()
         verify_stream_contains(httpx_mock.get_request(), "downloadFrom", "http://example.com/file.pdf")
+
+    def test_download_from_extra_http_headers(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).download_from(
+                [
+                    DownloadFromUrl(
+                        url="http://example.com/file.pdf",
+                        extra_http_headers={"Authorization": "Bearer token"},
+                    ),
+                ],
+            ).run()
+        verify_stream_contains(httpx_mock.get_request(), "downloadFrom", "extraHttpHeaders")
+
+    def test_download_from_field(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).download_from(
+                [
+                    DownloadFromUrl(url="http://example.com/file.pdf", field="watermark"),
+                ],
+            ).run()
+        verify_stream_contains(httpx_mock.get_request(), "downloadFrom", "watermark")

--- a/tests/test_common_mixins.py
+++ b/tests/test_common_mixins.py
@@ -59,6 +59,28 @@ class TestWatermarkMixin:
             route.url(webserver_docker_internal_url).watermark_options(WatermarkStampOptions(font="Arial")).run()
         verify_stream_contains(httpx_mock.get_request(), "watermarkOptions", "Arial")
 
+    def test_watermark_options_points(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_options(WatermarkStampOptions(points=14)).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkOptions", "14")
+
+    def test_watermark_options_rotation(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).watermark_options(WatermarkStampOptions(rotation=45)).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkOptions", "45")
+
     def test_watermark_file(
         self,
         sync_client: GotenbergClient,
@@ -119,6 +141,28 @@ class TestStampMixin:
         with sync_client.chromium.url_to_pdf() as route:
             route.url(webserver_docker_internal_url).stamp_options(WatermarkStampOptions(color="#FF0000")).run()
         verify_stream_contains(httpx_mock.get_request(), "stampOptions", "#FF0000")
+
+    def test_stamp_options_opacity(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_options(WatermarkStampOptions(opacity=0.5)).run()
+        verify_stream_contains(httpx_mock.get_request(), "stampOptions", "0.5")
+
+    def test_stamp_options_scale(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).stamp_options(WatermarkStampOptions(scale=0.8)).run()
+        verify_stream_contains(httpx_mock.get_request(), "stampOptions", "0.8")
 
     def test_stamp_file(
         self,

--- a/tests/test_convert_chromium_url.py
+++ b/tests/test_convert_chromium_url.py
@@ -268,3 +268,14 @@ class TestConvertChromiumUrlMocked:
             "extraHttpHeaders",
             json.dumps(headers),
         )
+
+    def test_convert_url_flatten(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).flatten(flatten=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "flatten", "true")

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pikepdf
 import pytest
+from pytest_httpx import HTTPXMock
 
 from gotenberg_client import GotenbergClient
 from gotenberg_client import SingleFileResponse
@@ -16,6 +17,8 @@ from gotenberg_client._libreoffice.routes import AsyncOfficeDocumentToPdfRoute
 from gotenberg_client._utils import guess_mime_type_stdlib
 from gotenberg_client.options import PageOrientation
 from gotenberg_client.options import PdfAFormat
+from gotenberg_client.options import WatermarkStampSource
+from tests.utils import verify_stream_contains
 
 
 class TestLibreOfficeConvert:
@@ -272,3 +275,27 @@ class TestLibreOfficeProperties:
         assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
+
+
+class TestLibreOfficeMocked:
+    def test_libreoffice_watermark_source(
+        self,
+        sync_client: GotenbergClient,
+        httpx_mock: HTTPXMock,
+        docx_sample_file: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).watermark_source(WatermarkStampSource.Text).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkSource", "text")
+
+    def test_libreoffice_user_password(
+        self,
+        sync_client: GotenbergClient,
+        httpx_mock: HTTPXMock,
+        docx_sample_file: Path,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).user_password("secret").run()
+        verify_stream_contains(httpx_mock.get_request(), "userPassword", "secret")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: 2023-present Trenton H <rda0128ou@mozmail.com>
 #
 # SPDX-License-Identifier: MPL-2.0
+import pytest
+
 from gotenberg_client._health import AsyncHealthCheckApi
 from gotenberg_client._health import StatusOptions
 from gotenberg_client._health import SyncHealthCheckApi
 
 
+@pytest.mark.flaky(reruns=3)
 class TestHealthStatus:
     def test_health_endpoint(
         self,

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -6,11 +6,14 @@ from pathlib import Path
 import pikepdf
 import pytest
 from httpx import codes
+from pytest_httpx import HTTPXMock
 
 from gotenberg_client import GotenbergClient
 from gotenberg_client._merge.routes import AsyncMergePdfsRoute
 from gotenberg_client.options import PdfAFormat
+from gotenberg_client.options import WatermarkStampSource
 from tests.utils import extract_text
+from tests.utils import verify_stream_contains
 
 
 class TestMergePdfs:
@@ -94,3 +97,27 @@ class TestMergePdfsAsync:
         assert len(lines) == 2
         assert "first PDF to be merged." in lines[0]
         assert "second PDF to be merged." in lines[1]
+
+
+class TestMergePdfsMocked:
+    def test_merge_watermark_source(
+        self,
+        sync_client: GotenbergClient,
+        sample_directory: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.merge.merge() as route:
+            route.merge([sample_directory / "sample1.pdf"]).watermark_source(WatermarkStampSource.Text).run()
+        verify_stream_contains(httpx_mock.get_request(), "watermarkSource", "text")
+
+    def test_merge_encrypt(
+        self,
+        sync_client: GotenbergClient,
+        sample_directory: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.merge.merge() as route:
+            route.merge([sample_directory / "sample1.pdf"]).user_password("pw").run()
+        verify_stream_contains(httpx_mock.get_request(), "userPassword", "pw")

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
+from pytest_httpx import HTTPXMock
+
+from gotenberg_client import GotenbergClient
 from gotenberg_client._others.routes import AsyncSplitRoute
+from tests.utils import verify_stream_contains
 
 
 class TestSplitApi:
@@ -8,3 +12,16 @@ class TestSplitApi:
         await (
             async_split_route.split_files([pdf_sample_one_file]).split_mode("pages").split_span("1,3").run_with_retry()
         )
+
+
+class TestSplitMocked:
+    def test_split_user_password(
+        self,
+        sync_client: GotenbergClient,
+        sample_directory: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.split.split() as route:
+            route.split(sample_directory / "sample1.pdf").split_mode("pages").split_span("1").user_password("pw").run()
+        verify_stream_contains(httpx_mock.get_request(), "userPassword", "pw")


### PR DESCRIPTION
  New option types (options.py):
  - WatermarkStampSource enum - Text, Image, Pdf
  - RotateAngle enum - Clockwise90, Clockwise180, Clockwise270
  - WatermarkStampOptions dataclass - font, points, color, rotation, opacity, scale
  - DownloadFromUrl dataclass - url, extra_http_headers, embedded, field (preferred over embedded)

  New mixins (_common/mixins.py), wired into Chromium PDF, LibreOffice, Merge, and Split routes:
  - WatermarkMixin - watermark_source, watermark_expression, watermark_pages, watermark_options, watermark_file
  - StampMixin - stamp_source, stamp_expression, stamp_pages, stamp_options, stamp_file
  - RotateMixin - rotate(angle, pages=None)
  - EncryptMixin - user_password, owner_password
  - EmbedsMixin - embed(file_path), embed_files(file_paths)
  - DownloadFromMixin - download_from(urls)
  - FlattenOptionMixin - now wired into Chromium PDF routes (was previously unwired)

  Internal refactor: RequestFiles changed from dict to list[tuple[str, FileEntry]] to support repeated multipart field names (required for embeds). ForceMultipartDict → ForceMultipartList; URL route's
  _get_all_resources now calls super() so embed files are included.

  Docs: ref_options.md completed (added PdfAFormat, TrappedStatus; Attributes: sections on all types); mkdocstrings filters hide internal methods globally; routes.md documents all new options.