### PR TITLE
Feature: Fill in the route specific fields which were missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `RotateAngle` enum (`Clockwise90`, `Clockwise180`, `Clockwise270`)
     - `WatermarkStampOptions` dataclass (font, points, color, rotation, opacity, scale)
     - `DownloadFromUrl` dataclass (url, extra_http_headers, embedded, field)
+- New Chromium route options (available on all PDF and screenshot routes):
+    - `wait_for_selector(selector)` — wait for a CSS selector before rendering
+    - `emulated_media_features(features)` — override CSS media features (e.g. `prefers-color-scheme`)
+    - `fail_on_resource_status_codes(codes)` — fail if any loaded resource returns a listed HTTP status code
+    - `ignore_resource_status_domains(domains)` — exclude specific domains from resource status code checks
+    - `skip_network_almost_idle(*, skip)` — skip the network "almost idle" event for faster rendering
+- New Chromium PDF-only options:
+    - `generate_tagged_pdf(*, generate)` — generate a tagged (accessible) PDF structure
+- New Chromium PDF route convenience methods on `HeaderFooterMixin`:
+    - `string_header(html)` — set the header from an in-memory HTML string
+    - `string_footer(html)` — set the footer from an in-memory HTML string
+- New LibreOffice route options:
+    - `export_placeholders(*, export_placeholders)` — export placeholder fields to PDF
+    - Native watermark support via `LibreOfficeNativeWatermarkMixin`: `native_watermark_text()`,
+      `native_watermark_color()`, `native_watermark_font_height()`, `native_watermark_rotate_angle()`,
+      `native_watermark_font_name()`, `native_tiled_watermark_text()`
+    - PDF viewer preferences via `LibreOfficeViewerPreferencesMixin`: `initial_view()`, `initial_page()`,
+      `magnification()`, `zoom()`, `page_layout()`, `first_page_on_left()`,
+      `resize_window_to_initial_page()`, `center_window()`, `open_in_full_screen_mode()`,
+      `display_pdf_document_title()`, `hide_viewer_menubar()`, `hide_viewer_toolbar()`,
+      `hide_viewer_window_controls()`, `use_transition_effects()`, `open_bookmark_levels()`
+    - New enums `InitialView`, `MagnificationOption`, and `PageLayout` in `gotenberg_client.options`
+      for use with viewer preference methods
+- New Merge PDF route options:
+    - `auto_index_bookmarks(*, enable)` — auto-extract bookmarks from input PDFs and re-index page numbers
+    - `merge_bookmarks(bookmark_list)` — set custom bookmarks on the merged PDF
 
 ### Changed
 

--- a/docs/ref_options.md
+++ b/docs/ref_options.md
@@ -35,3 +35,12 @@
 
 ::: gotenberg_client.options.DownloadFromUrl
     handler: python
+
+::: gotenberg_client.options.InitialView
+    handler: python
+
+::: gotenberg_client.options.MagnificationOption
+    handler: python
+
+::: gotenberg_client.options.PageLayout
+    handler: python

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -96,10 +96,13 @@ Three screenshot routes are available, each corresponding to a different input s
 This route also supports other Chromium options:
 
 - [Wait Before Rendering](#render-control)
+- [JavaScript Timing](#javascript-timing)
 - [Emulated Media Type](#emulated-media-type)
+- [Emulated Media Features](#emulated-media-features)
 - [Cookies](#cookies)
 - [Custom HTTP headers](#custom-http-headers)
 - [Invalid HTTP Status Codes](#http-status-codes)
+- [Resource Status Codes](#resource-status-codes)
 - [Console Exceptions](#console-exceptions)
 - [Performance Mode](#performance-mode)
 
@@ -126,10 +129,12 @@ This route also supports other Chromium options:
 
 [Gotenberg Documentation Link](https://gotenberg.dev/docs/routes#header-footer-chromium)
 
-| Gotenberg Option | Route Configuration | Python Type | Notes |
-| ---------------- | ------------------- | ----------- | ----- |
-| `header.html`    | `.header()`         | `Path`      |       |
-| `footer.html`    | `.footer()`         | `Path`      |       |
+| Gotenberg Option | Route Configuration    | Python Type | Notes                                         |
+| ---------------- | ---------------------- | ----------- | --------------------------------------------- |
+| `header.html`    | `.header()`            | `Path`      |                                               |
+| `footer.html`    | `.footer()`            | `Path`      |                                               |
+| `header.html`    | `.string_header(html)` | `str`       | sets the header from an in-memory HTML string |
+| `footer.html`    | `.string_footer(html)` | `str`       | sets the footer from an in-memory HTML string |
 
 #### Render Control
 
@@ -193,9 +198,43 @@ This route also supports other Chromium options:
 
 [Gotenberg Documentation Link](https://gotenberg.dev/docs/routes#performance-mode-chromium)
 
-| Gotenberg Option       | Route Configuration                                               | Python Type | Notes |
-| ---------------------- | ----------------------------------------------------------------- | ----------- | ----- |
-| `skipNetworkIdleEvent` | <ul><li>`.skip_network_idle()`<li>`.use_network_idle()`</li></ul> | N/A         |       |
+| Gotenberg Option             | Route Configuration                                               | Python Type | Notes        |
+| ---------------------------- | ----------------------------------------------------------------- | ----------- | ------------ |
+| `skipNetworkIdleEvent`       | <ul><li>`.skip_network_idle()`<li>`.use_network_idle()`</li></ul> | N/A         |              |
+| `skipNetworkAlmostIdleEvent` | `.skip_network_almost_idle(*, skip)`                              | `bool`      | keyword only |
+
+#### JavaScript Timing
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#javascript-timing)
+
+| Gotenberg Option  | Route Configuration    | Python Type | Notes |
+| ----------------- | ---------------------- | ----------- | ----- |
+| `waitForSelector` | `.wait_for_selector()` | `str`       |       |
+
+#### Emulated Media Features
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#emulated-media-type)
+
+| Gotenberg Option        | Route Configuration          | Python Type            | Notes                                                      |
+| ----------------------- | ---------------------------- | ---------------------- | ---------------------------------------------------------- |
+| `emulatedMediaFeatures` | `.emulated_media_features()` | `list[dict[str, str]]` | e.g. `[{"name": "prefers-color-scheme", "value": "dark"}]` |
+
+#### Resource Status Codes
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#invalid-http-status-codes)
+
+| Gotenberg Option                  | Route Configuration                 | Python Type            | Notes |
+| --------------------------------- | ----------------------------------- | ---------------------- | ----- |
+| `failOnResourceHttpStatusCodes`   | `.fail_on_resource_status_codes()`  | `Iterable[HTTPStatus]` |       |
+| `ignoreResourceHttpStatusDomains` | `.ignore_resource_status_domains()` | `list[str]`            |       |
+
+#### Accessibility (PDF routes only)
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#accessibility)
+
+| Gotenberg Option    | Route Configuration                 | Python Type | Notes                         |
+| ------------------- | ----------------------------------- | ----------- | ----------------------------- |
+| `generateTaggedPdf` | `.generate_tagged_pdf(*, generate)` | `bool`      | keyword only; PDF routes only |
 
 #### Split
 
@@ -306,6 +345,7 @@ section for details.
 | `exportHiddenSlides`              | `.export_hidden_slides()`                | `bool`            | keyword only; presentations only |
 | `skipEmptyPages`                  | `.skip_empty_pages()`                    | `bool`            | keyword only                     |
 | `addOriginalDocumentAsStream`     | `.add_original_document_as_stream()`     | `bool`            | keyword only                     |
+| `exportPlaceholders`              | `.export_placeholders()`                 | `bool`            | keyword only                     |
 
 #### Compress
 
@@ -362,6 +402,48 @@ See [PDF Metadata Support](#pdf-metadata-support) for the API interface.
 | Gotenberg Option | Route Configuration | Python Type | Notes        |
 | ---------------- | ------------------- | ----------- | ------------ |
 | `flatten`        | `.flatten()`        | `bool`      | keyword only |
+
+#### Native Watermark
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf)
+
+Apply a watermark using LibreOffice's own watermarking engine (distinct from the pdfcpu/pdftk-based
+[Watermark](#watermark) in Global Options).
+
+| Gotenberg Option             | Route Configuration                | Python Type | Notes                                               |
+| ---------------------------- | ---------------------------------- | ----------- | --------------------------------------------------- |
+| `nativeWatermarkText`        | `.native_watermark_text()`         | `str`       | center watermark text                               |
+| `nativeWatermarkColor`       | `.native_watermark_color()`        | `int`       | RGB color as integer (e.g. `0x808080`)              |
+| `nativeWatermarkFontHeight`  | `.native_watermark_font_height()`  | `int`       | font size in points                                 |
+| `nativeWatermarkRotateAngle` | `.native_watermark_rotate_angle()` | `int`       | rotation in tenths of a degree (e.g. `450` = 45.0°) |
+| `nativeWatermarkFontName`    | `.native_watermark_font_name()`    | `str`       | font name                                           |
+| `nativeTiledWatermarkText`   | `.native_tiled_watermark_text()`   | `str`       | tiled watermark text repeated across page           |
+
+#### PDF Viewer Preferences
+
+[Gotenberg Documentation](https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf)
+
+Set PDF viewer preferences that are embedded into the output PDF by LibreOffice.
+
+| Gotenberg Option            | Route Configuration                      | Python Type           | Notes                         |
+| --------------------------- | ---------------------------------------- | --------------------- | ----------------------------- |
+| `initialView`               | `.initial_view()`                        | `InitialView`         | panel open on initial display |
+| `initialPage`               | `.initial_page()`                        | `int`                 | page to display initially     |
+| `magnification`             | `.magnification()`                       | `MagnificationOption` | initial zoom level            |
+| `zoom`                      | `.zoom()`                                | `int`                 | zoom percentage               |
+| `pageLayout`                | `.page_layout()`                         | `PageLayout`          | page layout mode              |
+| `firstPageOnLeft`           | `.first_page_on_left(*, ...)`            | `bool`                | keyword only                  |
+| `resizeWindowToInitialPage` | `.resize_window_to_initial_page(*, ...)` | `bool`                | keyword only                  |
+| `centerWindow`              | `.center_window(*, ...)`                 | `bool`                | keyword only                  |
+| `openInFullScreenMode`      | `.open_in_full_screen_mode(*, ...)`      | `bool`                | keyword only                  |
+| `displayPDFDocumentTitle`   | `.display_pdf_document_title(*, ...)`    | `bool`                | keyword only                  |
+| `hideViewerMenubar`         | `.hide_viewer_menubar(*, ...)`           | `bool`                | keyword only                  |
+| `hideViewerToolbar`         | `.hide_viewer_toolbar(*, ...)`           | `bool`                | keyword only                  |
+| `hideViewerWindowControls`  | `.hide_viewer_window_controls(*, ...)`   | `bool`                | keyword only                  |
+| `useTransitionEffects`      | `.use_transition_effects(*, ...)`        | `bool`                | keyword only                  |
+| `openBookmarkLevels`        | `.open_bookmark_levels()`                | `int`                 | `-1` to open all levels       |
+
+`InitialView`, `MagnificationOption`, and `PageLayout` are importable from `gotenberg_client.options`.
 
 #### Watermark, Stamp, Rotate, Encrypt, Embeds, Download From
 
@@ -463,18 +545,20 @@ Required Properties:
 
 Optional Properties:
 
-| Gotenberg Option | Route Configuration                                                             | Python Type             | Notes                                             |
-| ---------------- | ------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------- |
-| `pdfa`           | `.pdf_format()`                                                                 | `PdfAFormat`            |                                                   |
-| `pdfua`          | <ul><li>`.enable_universal_access()`<li>`.disable_universal_access()`</li></ul> | N/A                     |                                                   |
-| `flatten`        | `.flatten()`                                                                    | `bool`                  | keyword only                                      |
-| `metadata`       | `.metadata()`                                                                   | N/A                     | See [PDF Metadata Support](#pdf-metadata-support) |
-| watermark        | See [Watermark](#watermark)                                                     | `WatermarkStampSource`  |                                                   |
-| stamp            | See [Stamp](#stamp)                                                             | `WatermarkStampSource`  |                                                   |
-| rotate           | `.rotate()`                                                                     | `RotateAngle`           |                                                   |
-| encrypt          | `.user_password()` / `.owner_password()`                                        | `str`                   |                                                   |
-| embeds           | `.embed()` / `.embed_files()`                                                   | `Path` / `list[Path]`   |                                                   |
-| downloadFrom     | `.download_from()`                                                              | `list[DownloadFromUrl]` |                                                   |
+| Gotenberg Option     | Route Configuration                                                             | Python Type             | Notes                                                                          |
+| -------------------- | ------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| `pdfa`               | `.pdf_format()`                                                                 | `PdfAFormat`            |                                                                                |
+| `pdfua`              | <ul><li>`.enable_universal_access()`<li>`.disable_universal_access()`</li></ul> | N/A                     |                                                                                |
+| `flatten`            | `.flatten()`                                                                    | `bool`                  | keyword only                                                                   |
+| `metadata`           | `.metadata()`                                                                   | N/A                     | See [PDF Metadata Support](#pdf-metadata-support)                              |
+| `autoIndexBookmarks` | `.auto_index_bookmarks(*, enable)`                                              | `bool`                  | keyword only; re-index bookmark page numbers                                   |
+| `bookmarks`          | `.merge_bookmarks(bookmark_list)`                                               | `list[dict[str, Any]]`  | custom bookmarks; each entry: `{"title": str, "page": int, "children": [...]}` |
+| watermark            | See [Watermark](#watermark)                                                     | `WatermarkStampSource`  |                                                                                |
+| stamp                | See [Stamp](#stamp)                                                             | `WatermarkStampSource`  |                                                                                |
+| rotate               | `.rotate()`                                                                     | `RotateAngle`           |                                                                                |
+| encrypt              | `.user_password()` / `.owner_password()`                                        | `str`                   |                                                                                |
+| embeds               | `.embed()` / `.embed_files()`                                                   | `Path` / `list[Path]`   |                                                                                |
+| downloadFrom         | `.download_from()`                                                              | `list[DownloadFromUrl]` |                                                                                |
 
 ```python
 from gotenberg_client import GotenbergClient

--- a/src/gotenberg_client/_chromium/mixins.py
+++ b/src/gotenberg_client/_chromium/mixins.py
@@ -316,6 +316,20 @@ class HeaderFooterMixin:
         self._add_file_map(footer, name="footer.html")  # type: ignore[attr-defined]
         return self
 
+    def string_header(self, html: str) -> Self:
+        """
+        Sets the header from an in-memory HTML string instead of a file path.
+        """
+        self._add_in_memory_file(html, name="header.html", mime_type="text/html")  # type: ignore[attr-defined]
+        return self
+
+    def string_footer(self, html: str) -> Self:
+        """
+        Sets the footer from an in-memory HTML string instead of a file path.
+        """
+        self._add_in_memory_file(html, name="footer.html", mime_type="text/html")  # type: ignore[attr-defined]
+        return self
+
 
 class RenderControlMixin:
     """
@@ -621,4 +635,15 @@ class NetworkAlmostIdleMixin:
 
     def skip_network_almost_idle(self, *, skip: bool) -> Self:
         self._form_data.update(bool_to_form("skipNetworkAlmostIdleEvent", skip))  # type: ignore[attr-defined,misc]
+        return self
+
+
+class GenerateTaggedPdfMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#accessibility
+    Generate a tagged (structured) PDF for improved accessibility.
+    """
+
+    def generate_tagged_pdf(self, *, generate: bool) -> Self:
+        self._form_data.update(bool_to_form("generateTaggedPdf", generate))  # type: ignore[attr-defined,misc]
         return self

--- a/src/gotenberg_client/_chromium/mixins.py
+++ b/src/gotenberg_client/_chromium/mixins.py
@@ -586,7 +586,5 @@ class EmulatedMediaFeaturesMixin:
     """
 
     def emulated_media_features(self, features: list[dict[str, str]]) -> Self:
-        import json  # noqa: PLC0415
-
         self._form_data.update({"emulatedMediaFeatures": json.dumps(features)})  # type: ignore[attr-defined,misc]
         return self

--- a/src/gotenberg_client/_chromium/mixins.py
+++ b/src/gotenberg_client/_chromium/mixins.py
@@ -588,3 +588,37 @@ class EmulatedMediaFeaturesMixin:
     def emulated_media_features(self, features: list[dict[str, str]]) -> Self:
         self._form_data.update({"emulatedMediaFeatures": json.dumps(features)})  # type: ignore[attr-defined,misc]
         return self
+
+
+class ResourceStatusCodesMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#invalid-http-status-codes
+    Fail the conversion if any loaded resource returns one of the specified HTTP status codes.
+    """
+
+    def fail_on_resource_status_codes(self, codes: Iterable[HTTPStatus]) -> Self:
+        codes_str = ",".join([str(int(x)) for x in codes])
+        self._form_data.update({"failOnResourceHttpStatusCodes": f"[{codes_str}]"})  # type: ignore[attr-defined,misc]
+        return self
+
+
+class IgnoreResourceDomainsMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#invalid-http-status-codes
+    Domains to exclude from resource status code checking.
+    """
+
+    def ignore_resource_status_domains(self, domains: list[str]) -> Self:
+        self._form_data.update({"ignoreResourceHttpStatusDomains": json.dumps(domains)})  # type: ignore[attr-defined,misc]
+        return self
+
+
+class NetworkAlmostIdleMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#performance-mode
+    Also skip the network 'almost idle' event for even faster rendering.
+    """
+
+    def skip_network_almost_idle(self, *, skip: bool) -> Self:
+        self._form_data.update(bool_to_form("skipNetworkAlmostIdleEvent", skip))  # type: ignore[attr-defined,misc]
+        return self

--- a/src/gotenberg_client/_chromium/mixins.py
+++ b/src/gotenberg_client/_chromium/mixins.py
@@ -566,3 +566,27 @@ class ScreenShotSettingsMixin:
             ScreenshotRoute: This object itself for method chaining.
         """
         return self.image_optimize(optimize_for_speed=False)
+
+
+class WaitForSelectorMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#javascript-timing
+    Wait for a CSS selector to appear before rendering.
+    """
+
+    def wait_for_selector(self, selector: str) -> Self:
+        self._form_data.update({"waitForSelector": selector})  # type: ignore[attr-defined,misc]
+        return self
+
+
+class EmulatedMediaFeaturesMixin:
+    """
+    https://gotenberg.dev/docs/convert-with-chromium/convert-url-to-pdf#emulated-media-type
+    Override specific CSS media features (e.g., prefers-color-scheme).
+    """
+
+    def emulated_media_features(self, features: list[dict[str, str]]) -> Self:
+        import json  # noqa: PLC0415
+
+        self._form_data.update({"emulatedMediaFeatures": json.dumps(features)})  # type: ignore[attr-defined,misc]
+        return self

--- a/src/gotenberg_client/_chromium/routes.py
+++ b/src/gotenberg_client/_chromium/routes.py
@@ -14,9 +14,11 @@ from gotenberg_client._chromium.mixins import DocumentOutlineMixin
 from gotenberg_client._chromium.mixins import EmulatedMediaFeaturesMixin
 from gotenberg_client._chromium.mixins import EmulatedMediaMixin
 from gotenberg_client._chromium.mixins import HeaderFooterMixin
+from gotenberg_client._chromium.mixins import IgnoreResourceDomainsMixin
 from gotenberg_client._chromium.mixins import InvalidStatusCodesMixin
 from gotenberg_client._chromium.mixins import MarginMixin
 from gotenberg_client._chromium.mixins import NativePageRangeMixin
+from gotenberg_client._chromium.mixins import NetworkAlmostIdleMixin
 from gotenberg_client._chromium.mixins import NetworkErrorsMixin
 from gotenberg_client._chromium.mixins import OmitBackgroundMixin
 from gotenberg_client._chromium.mixins import PageOrientMixin
@@ -24,6 +26,7 @@ from gotenberg_client._chromium.mixins import PageSizeMixin
 from gotenberg_client._chromium.mixins import PerformanceModeMixin
 from gotenberg_client._chromium.mixins import PrintBackgroundMixin
 from gotenberg_client._chromium.mixins import RenderControlMixin
+from gotenberg_client._chromium.mixins import ResourceStatusCodesMixin
 from gotenberg_client._chromium.mixins import ScaleMixin
 from gotenberg_client._chromium.mixins import ScreenShotSettingsMixin
 from gotenberg_client._chromium.mixins import SinglePageMixin
@@ -62,9 +65,12 @@ class _BaseChromiumConvertMixin(
     CookiesMixin,
     CustomHTTPHeaderMixin,
     InvalidStatusCodesMixin,
+    ResourceStatusCodesMixin,
+    IgnoreResourceDomainsMixin,
     NetworkErrorsMixin,
     ConsoleExceptionMixin,
     PerformanceModeMixin,
+    NetworkAlmostIdleMixin,
     SplitModeMixin,
     PdfFormatMixin,
     PdfUniversalAccessMixin,
@@ -374,8 +380,11 @@ class _BaseScreenShotSettingsMixin(
     CookiesMixin,
     CustomHTTPHeaderMixin,
     InvalidStatusCodesMixin,
+    ResourceStatusCodesMixin,
+    IgnoreResourceDomainsMixin,
     ConsoleExceptionMixin,
     PerformanceModeMixin,
+    NetworkAlmostIdleMixin,
     OmitBackgroundMixin,
     ScreenShotSettingsMixin,
 ):

--- a/src/gotenberg_client/_chromium/routes.py
+++ b/src/gotenberg_client/_chromium/routes.py
@@ -13,6 +13,7 @@ from gotenberg_client._chromium.mixins import CustomHTTPHeaderMixin
 from gotenberg_client._chromium.mixins import DocumentOutlineMixin
 from gotenberg_client._chromium.mixins import EmulatedMediaFeaturesMixin
 from gotenberg_client._chromium.mixins import EmulatedMediaMixin
+from gotenberg_client._chromium.mixins import GenerateTaggedPdfMixin
 from gotenberg_client._chromium.mixins import HeaderFooterMixin
 from gotenberg_client._chromium.mixins import IgnoreResourceDomainsMixin
 from gotenberg_client._chromium.mixins import InvalidStatusCodesMixin
@@ -71,6 +72,7 @@ class _BaseChromiumConvertMixin(
     ConsoleExceptionMixin,
     PerformanceModeMixin,
     NetworkAlmostIdleMixin,
+    GenerateTaggedPdfMixin,
     SplitModeMixin,
     PdfFormatMixin,
     PdfUniversalAccessMixin,

--- a/src/gotenberg_client/_chromium/routes.py
+++ b/src/gotenberg_client/_chromium/routes.py
@@ -11,6 +11,7 @@ from gotenberg_client._chromium.mixins import CookiesMixin
 from gotenberg_client._chromium.mixins import CssPageSizeMixin
 from gotenberg_client._chromium.mixins import CustomHTTPHeaderMixin
 from gotenberg_client._chromium.mixins import DocumentOutlineMixin
+from gotenberg_client._chromium.mixins import EmulatedMediaFeaturesMixin
 from gotenberg_client._chromium.mixins import EmulatedMediaMixin
 from gotenberg_client._chromium.mixins import HeaderFooterMixin
 from gotenberg_client._chromium.mixins import InvalidStatusCodesMixin
@@ -26,6 +27,7 @@ from gotenberg_client._chromium.mixins import RenderControlMixin
 from gotenberg_client._chromium.mixins import ScaleMixin
 from gotenberg_client._chromium.mixins import ScreenShotSettingsMixin
 from gotenberg_client._chromium.mixins import SinglePageMixin
+from gotenberg_client._chromium.mixins import WaitForSelectorMixin
 from gotenberg_client._common import DownloadFromMixin
 from gotenberg_client._common import EmbedsMixin
 from gotenberg_client._common import EncryptMixin
@@ -54,7 +56,9 @@ class _BaseChromiumConvertMixin(
     NativePageRangeMixin,
     HeaderFooterMixin,
     RenderControlMixin,
+    WaitForSelectorMixin,
     EmulatedMediaMixin,
+    EmulatedMediaFeaturesMixin,
     CookiesMixin,
     CustomHTTPHeaderMixin,
     InvalidStatusCodesMixin,
@@ -364,7 +368,9 @@ class AsyncMarkdownToPdfRoute(_BaseMarkdownToPdfRoute, AsyncBaseRoute):
 
 class _BaseScreenShotSettingsMixin(
     RenderControlMixin,
+    WaitForSelectorMixin,
     EmulatedMediaMixin,
+    EmulatedMediaFeaturesMixin,
     CookiesMixin,
     CustomHTTPHeaderMixin,
     InvalidStatusCodesMixin,

--- a/src/gotenberg_client/_libreoffice/mixins.py
+++ b/src/gotenberg_client/_libreoffice/mixins.py
@@ -2,70 +2,18 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import enum
 import logging
 from typing import Final
 from typing import Literal
 
 from gotenberg_client._typing_compat import Self
 from gotenberg_client._utils import bool_to_form
+from gotenberg_client.options import InitialView
+from gotenberg_client.options import MagnificationOption
+from gotenberg_client.options import PageLayout
 from gotenberg_client.options import PageOrientation
 
 logger = logging.getLogger(__name__)
-
-
-@enum.unique
-class InitialView(enum.IntEnum):
-    """
-    Controls which panel is open in the PDF viewer on initial display.
-
-    Attributes:
-        NONE: No panel open (default).
-        OUTLINE: Show document outline/bookmarks panel.
-        THUMBNAILS: Show page thumbnails panel.
-    """
-
-    NONE = 0
-    OUTLINE = 1
-    THUMBNAILS = 2
-
-
-@enum.unique
-class MagnificationOption(enum.IntEnum):
-    """
-    Controls the initial magnification/zoom level used by the PDF viewer.
-
-    Attributes:
-        DEFAULT: Use the viewer default.
-        FIT_PAGE: Fit the entire page in the window.
-        FIT_WIDTH: Fit the page width in the window.
-        FIT_HEIGHT: Fit the page height in the window.
-        FIT_BOX: Fit the bounding box of the page in the window.
-    """
-
-    DEFAULT = 0
-    FIT_PAGE = 1
-    FIT_WIDTH = 2
-    FIT_HEIGHT = 3
-    FIT_BOX = 4
-
-
-@enum.unique
-class PageLayout(enum.IntEnum):
-    """
-    Controls the page layout mode used by the PDF viewer on initial display.
-
-    Attributes:
-        DEFAULT: Use the viewer default.
-        SINGLE_PAGE: Display one page at a time.
-        CONTINUOUS: Display pages in a continuous vertical column.
-        TWO_COLUMNS: Display two pages side by side.
-    """
-
-    DEFAULT = 0
-    SINGLE_PAGE = 1
-    CONTINUOUS = 2
-    TWO_COLUMNS = 3
 
 
 class LibreOfficePagePropertiesMixin:

--- a/src/gotenberg_client/_libreoffice/mixins.py
+++ b/src/gotenberg_client/_libreoffice/mixins.py
@@ -257,6 +257,49 @@ class LibreOfficePagePropertiesMixin:
         self._form_data.update(bool_to_form("singlePageSheets", single_page_sheets))  # type: ignore[attr-defined,misc]
         return self
 
+    def export_placeholders(self, *, export_placeholders: bool = False) -> Self:
+        """
+        Controls whether placeholder fields should be exported to PDF.
+        """
+        self._form_data.update(bool_to_form("exportPlaceholders", export_placeholders))  # type: ignore[attr-defined,misc]
+        return self
+
+
+class LibreOfficeNativeWatermarkMixin:
+    """
+    LibreOffice-native watermark fields that use LibreOffice's own watermarking engine
+    (as opposed to the pdfcpu/pdftk-based watermark from WatermarkMixin).
+    See https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf
+    """
+
+    def native_watermark_text(self, text: str) -> Self:
+        """Center watermark text rendered by LibreOffice."""
+        self._form_data.update({"nativeWatermarkText": text})  # type: ignore[attr-defined,misc]
+        return self
+
+    def native_watermark_color(self, color: int) -> Self:
+        """RGB color as integer (e.g., 0x808080 for grey)."""
+        self._form_data.update({"nativeWatermarkColor": str(color)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def native_watermark_font_height(self, height: int) -> Self:
+        self._form_data.update({"nativeWatermarkFontHeight": str(height)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def native_watermark_rotate_angle(self, angle: int) -> Self:
+        """Rotation in tenths of a degree (e.g., 450 = 45.0°)."""
+        self._form_data.update({"nativeWatermarkRotateAngle": str(angle)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def native_watermark_font_name(self, font_name: str) -> Self:
+        self._form_data.update({"nativeWatermarkFontName": font_name})  # type: ignore[attr-defined,misc]
+        return self
+
+    def native_tiled_watermark_text(self, text: str) -> Self:
+        """Tiled watermark text repeated across the page."""
+        self._form_data.update({"nativeTiledWatermarkText": text})  # type: ignore[attr-defined,misc]
+        return self
+
 
 class LibreOfficeCompressOptionsMixin:
     """

--- a/src/gotenberg_client/_libreoffice/mixins.py
+++ b/src/gotenberg_client/_libreoffice/mixins.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import enum
 import logging
 from typing import Final
 from typing import Literal
@@ -11,6 +12,60 @@ from gotenberg_client._utils import bool_to_form
 from gotenberg_client.options import PageOrientation
 
 logger = logging.getLogger(__name__)
+
+
+@enum.unique
+class InitialView(enum.IntEnum):
+    """
+    Controls which panel is open in the PDF viewer on initial display.
+
+    Attributes:
+        NONE: No panel open (default).
+        OUTLINE: Show document outline/bookmarks panel.
+        THUMBNAILS: Show page thumbnails panel.
+    """
+
+    NONE = 0
+    OUTLINE = 1
+    THUMBNAILS = 2
+
+
+@enum.unique
+class MagnificationOption(enum.IntEnum):
+    """
+    Controls the initial magnification/zoom level used by the PDF viewer.
+
+    Attributes:
+        DEFAULT: Use the viewer default.
+        FIT_PAGE: Fit the entire page in the window.
+        FIT_WIDTH: Fit the page width in the window.
+        FIT_HEIGHT: Fit the page height in the window.
+        FIT_BOX: Fit the bounding box of the page in the window.
+    """
+
+    DEFAULT = 0
+    FIT_PAGE = 1
+    FIT_WIDTH = 2
+    FIT_HEIGHT = 3
+    FIT_BOX = 4
+
+
+@enum.unique
+class PageLayout(enum.IntEnum):
+    """
+    Controls the page layout mode used by the PDF viewer on initial display.
+
+    Attributes:
+        DEFAULT: Use the viewer default.
+        SINGLE_PAGE: Display one page at a time.
+        CONTINUOUS: Display pages in a continuous vertical column.
+        TWO_COLUMNS: Display two pages side by side.
+    """
+
+    DEFAULT = 0
+    SINGLE_PAGE = 1
+    CONTINUOUS = 2
+    TWO_COLUMNS = 3
 
 
 class LibreOfficePagePropertiesMixin:
@@ -383,27 +438,27 @@ class LibreOfficeViewerPreferencesMixin:
     See https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf
     """
 
-    def initial_view(self, view: int) -> Self:
-        """0=none, 1=outline, 2=thumbnails."""
-        self._form_data.update({"initialView": str(view)})  # type: ignore[attr-defined,misc]
+    def initial_view(self, view: InitialView) -> Self:
+        """Set which panel is open in the PDF viewer (none, outline, or thumbnails)."""
+        self._form_data.update({"initialView": str(int(view))})  # type: ignore[attr-defined,misc]
         return self
 
     def initial_page(self, page: int) -> Self:
         self._form_data.update({"initialPage": str(page)})  # type: ignore[attr-defined,misc]
         return self
 
-    def magnification(self, magnification: int) -> Self:
-        """0=default, 1=fit page, 2=fit width, 3=fit height, 4=fit box."""
-        self._form_data.update({"magnification": str(magnification)})  # type: ignore[attr-defined,misc]
+    def magnification(self, magnification: MagnificationOption) -> Self:
+        """Set the initial magnification/zoom level in the PDF viewer."""
+        self._form_data.update({"magnification": str(int(magnification))})  # type: ignore[attr-defined,misc]
         return self
 
     def zoom(self, zoom_percent: int) -> Self:
         self._form_data.update({"zoom": str(zoom_percent)})  # type: ignore[attr-defined,misc]
         return self
 
-    def page_layout(self, layout: int) -> Self:
-        """0=default, 1=single page, 2=continuous, 3=two columns."""
-        self._form_data.update({"pageLayout": str(layout)})  # type: ignore[attr-defined,misc]
+    def page_layout(self, layout: PageLayout) -> Self:
+        """Set the page layout mode used by the PDF viewer."""
+        self._form_data.update({"pageLayout": str(int(layout))})  # type: ignore[attr-defined,misc]
         return self
 
     def first_page_on_left(self, *, first_page_on_left: bool) -> Self:

--- a/src/gotenberg_client/_libreoffice/mixins.py
+++ b/src/gotenberg_client/_libreoffice/mixins.py
@@ -377,6 +377,77 @@ class LibreOfficeCompressOptionsMixin:
         return self
 
 
+class LibreOfficeViewerPreferencesMixin:
+    """
+    PDF viewer preferences set by LibreOffice during conversion.
+    See https://gotenberg.dev/docs/convert-with-libreoffice/convert-to-pdf
+    """
+
+    def initial_view(self, view: int) -> Self:
+        """0=none, 1=outline, 2=thumbnails."""
+        self._form_data.update({"initialView": str(view)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def initial_page(self, page: int) -> Self:
+        self._form_data.update({"initialPage": str(page)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def magnification(self, magnification: int) -> Self:
+        """0=default, 1=fit page, 2=fit width, 3=fit height, 4=fit box."""
+        self._form_data.update({"magnification": str(magnification)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def zoom(self, zoom_percent: int) -> Self:
+        self._form_data.update({"zoom": str(zoom_percent)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def page_layout(self, layout: int) -> Self:
+        """0=default, 1=single page, 2=continuous, 3=two columns."""
+        self._form_data.update({"pageLayout": str(layout)})  # type: ignore[attr-defined,misc]
+        return self
+
+    def first_page_on_left(self, *, first_page_on_left: bool) -> Self:
+        self._form_data.update(bool_to_form("firstPageOnLeft", first_page_on_left))  # type: ignore[attr-defined,misc]
+        return self
+
+    def resize_window_to_initial_page(self, *, resize: bool) -> Self:
+        self._form_data.update(bool_to_form("resizeWindowToInitialPage", resize))  # type: ignore[attr-defined,misc]
+        return self
+
+    def center_window(self, *, center: bool) -> Self:
+        self._form_data.update(bool_to_form("centerWindow", center))  # type: ignore[attr-defined,misc]
+        return self
+
+    def open_in_full_screen_mode(self, *, full_screen: bool) -> Self:
+        self._form_data.update(bool_to_form("openInFullScreenMode", full_screen))  # type: ignore[attr-defined,misc]
+        return self
+
+    def display_pdf_document_title(self, *, display_title: bool) -> Self:
+        self._form_data.update(bool_to_form("displayPDFDocumentTitle", display_title))  # type: ignore[attr-defined,misc]
+        return self
+
+    def hide_viewer_menubar(self, *, hide: bool) -> Self:
+        self._form_data.update(bool_to_form("hideViewerMenubar", hide))  # type: ignore[attr-defined,misc]
+        return self
+
+    def hide_viewer_toolbar(self, *, hide: bool) -> Self:
+        self._form_data.update(bool_to_form("hideViewerToolbar", hide))  # type: ignore[attr-defined,misc]
+        return self
+
+    def hide_viewer_window_controls(self, *, hide: bool) -> Self:
+        self._form_data.update(bool_to_form("hideViewerWindowControls", hide))  # type: ignore[attr-defined,misc]
+        return self
+
+    def use_transition_effects(self, *, use: bool) -> Self:
+        self._form_data.update(bool_to_form("useTransitionEffects", use))  # type: ignore[attr-defined,misc]
+        return self
+
+    def open_bookmark_levels(self, levels: int) -> Self:
+        """Number of bookmark levels to open in the viewer (-1 = all)."""
+        self._form_data.update({"openBookmarkLevels": str(levels)})  # type: ignore[attr-defined,misc]
+        return self
+
+
 class LibreOfficeMergeOptionMixin:
     """
     Provides document merging options for LibreOffice conversions.

--- a/src/gotenberg_client/_libreoffice/routes.py
+++ b/src/gotenberg_client/_libreoffice/routes.py
@@ -22,12 +22,14 @@ from gotenberg_client._libreoffice.mixins import LibreOfficeCompressOptionsMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeMergeOptionMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeNativeWatermarkMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficePagePropertiesMixin
+from gotenberg_client._libreoffice.mixins import LibreOfficeViewerPreferencesMixin
 from gotenberg_client._typing_compat import Self
 
 
 class _BaseOfficeDocumentToPdfRoute(
     LibreOfficePagePropertiesMixin,
     LibreOfficeNativeWatermarkMixin,
+    LibreOfficeViewerPreferencesMixin,
     LibreOfficeCompressOptionsMixin,
     LibreOfficeMergeOptionMixin,
     SplitModeMixin,

--- a/src/gotenberg_client/_libreoffice/routes.py
+++ b/src/gotenberg_client/_libreoffice/routes.py
@@ -20,12 +20,14 @@ from gotenberg_client._common import StampMixin
 from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeCompressOptionsMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficeMergeOptionMixin
+from gotenberg_client._libreoffice.mixins import LibreOfficeNativeWatermarkMixin
 from gotenberg_client._libreoffice.mixins import LibreOfficePagePropertiesMixin
 from gotenberg_client._typing_compat import Self
 
 
 class _BaseOfficeDocumentToPdfRoute(
     LibreOfficePagePropertiesMixin,
+    LibreOfficeNativeWatermarkMixin,
     LibreOfficeCompressOptionsMixin,
     LibreOfficeMergeOptionMixin,
     SplitModeMixin,

--- a/src/gotenberg_client/_merge/routes.py
+++ b/src/gotenberg_client/_merge/routes.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2025-present Trenton H <rda0128ou@mozmail.com>
 #
 # SPDX-License-Identifier: MPL-2.0
+import json
 from pathlib import Path
+from typing import Any
 from typing import Final
 
 from gotenberg_client._base import AsyncBaseRoute
@@ -17,6 +19,7 @@ from gotenberg_client._common import RotateMixin
 from gotenberg_client._common import StampMixin
 from gotenberg_client._common import WatermarkMixin
 from gotenberg_client._typing_compat import Self
+from gotenberg_client._utils import bool_to_form
 
 
 class _BaseMergePdfFilesRoute(
@@ -68,6 +71,24 @@ class _BaseMergePdfFilesRoute(
             # Include index to enforce ordering
             self._add_file_map(filepath, name=f"{self._next:05d}_{filepath.name}")  # type: ignore[attr-defined,misc]
             self._next += 1  # type: ignore[attr-defined,misc]
+        return self
+
+    def auto_index_bookmarks(self, *, enable: bool) -> Self:
+        """
+        Auto-extract bookmarks from input PDFs and offset their page numbers
+        to match the merged document's page numbers.
+        https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs
+        """
+        self._form_data.update(bool_to_form("autoIndexBookmarks", enable))  # type: ignore[attr-defined,misc]
+        return self
+
+    def merge_bookmarks(self, bookmark_list: list[dict[str, Any]]) -> Self:
+        """
+        Set custom bookmarks for the merged PDF.
+        Each bookmark: {"title": str, "page": int, "children": [...]}
+        https://gotenberg.dev/docs/manipulate-pdfs/merge-pdfs
+        """
+        self._form_data.update({"bookmarks": json.dumps(bookmark_list)})  # type: ignore[attr-defined,misc]
         return self
 
 

--- a/src/gotenberg_client/options.py
+++ b/src/gotenberg_client/options.py
@@ -343,6 +343,66 @@ class WatermarkStampOptions:
         return json.dumps(data)
 
 
+@enum.unique
+class InitialView(enum.IntEnum):
+    """
+    Controls which panel is open in the PDF viewer on initial display.
+
+    Used with the LibreOffice route's `initial_view()` method.
+
+    Attributes:
+        NONE: No panel open (default).
+        OUTLINE: Show document outline/bookmarks panel.
+        THUMBNAILS: Show page thumbnails panel.
+    """
+
+    NONE = 0
+    OUTLINE = 1
+    THUMBNAILS = 2
+
+
+@enum.unique
+class MagnificationOption(enum.IntEnum):
+    """
+    Controls the initial magnification/zoom level used by the PDF viewer.
+
+    Used with the LibreOffice route's `magnification()` method.
+
+    Attributes:
+        DEFAULT: Use the viewer default.
+        FIT_PAGE: Fit the entire page in the window.
+        FIT_WIDTH: Fit the page width in the window.
+        FIT_HEIGHT: Fit the page height in the window.
+        FIT_BOX: Fit the bounding box of the page in the window.
+    """
+
+    DEFAULT = 0
+    FIT_PAGE = 1
+    FIT_WIDTH = 2
+    FIT_HEIGHT = 3
+    FIT_BOX = 4
+
+
+@enum.unique
+class PageLayout(enum.IntEnum):
+    """
+    Controls the page layout mode used by the PDF viewer on initial display.
+
+    Used with the LibreOffice route's `page_layout()` method.
+
+    Attributes:
+        DEFAULT: Use the viewer default.
+        SINGLE_PAGE: Display one page at a time.
+        CONTINUOUS: Display pages in a continuous vertical column.
+        TWO_COLUMNS: Display two pages side by side.
+    """
+
+    DEFAULT = 0
+    SINGLE_PAGE = 1
+    CONTINUOUS = 2
+    TWO_COLUMNS = 3
+
+
 @dataclasses.dataclass(slots=True)
 class DownloadFromUrl:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from collections.abc import AsyncGenerator
 from collections.abc import Generator
+from http import HTTPStatus
 from pathlib import Path
 
 import httpx
@@ -54,7 +55,7 @@ def is_responsive(url):
         logger.exception("Error connecting to service")
         return False
     else:
-        return response.status_code == httpx.codes.OK
+        return response.status_code == HTTPStatus.OK
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_convert_chromium_url.py
+++ b/tests/test_convert_chromium_url.py
@@ -279,3 +279,26 @@ class TestConvertChromiumUrlMocked:
         with sync_client.chromium.url_to_pdf() as route:
             route.url(webserver_docker_internal_url).flatten(flatten=True).run()
         verify_stream_contains(httpx_mock.get_request(), "flatten", "true")
+
+    def test_wait_for_selector(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).wait_for_selector("#main-content").run()
+        verify_stream_contains(httpx_mock.get_request(), "waitForSelector", "#main-content")
+
+    def test_emulated_media_features(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        features = [{"name": "prefers-color-scheme", "value": "dark"}]
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).emulated_media_features(features).run()
+        verify_stream_contains(httpx_mock.get_request(), "emulatedMediaFeatures", "prefers-color-scheme")

--- a/tests/test_convert_chromium_url.py
+++ b/tests/test_convert_chromium_url.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 import json
+from http import HTTPStatus
 from typing import Literal
 
 import pytest
@@ -302,3 +303,36 @@ class TestConvertChromiumUrlMocked:
         with sync_client.chromium.url_to_pdf() as route:
             route.url(webserver_docker_internal_url).emulated_media_features(features).run()
         verify_stream_contains(httpx_mock.get_request(), "emulatedMediaFeatures", "prefers-color-scheme")
+
+    def test_fail_on_resource_http_status_codes(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).fail_on_resource_status_codes([HTTPStatus.NOT_FOUND]).run()
+        verify_stream_contains(httpx_mock.get_request(), "failOnResourceHttpStatusCodes", "404")
+
+    def test_ignore_resource_http_status_domains(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).ignore_resource_status_domains(["cdn.example.com"]).run()
+        verify_stream_contains(httpx_mock.get_request(), "ignoreResourceHttpStatusDomains", "cdn.example.com")
+
+    def test_skip_network_almost_idle_event(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).skip_network_almost_idle(skip=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "skipNetworkAlmostIdleEvent", "true")

--- a/tests/test_convert_chromium_url.py
+++ b/tests/test_convert_chromium_url.py
@@ -336,3 +336,42 @@ class TestConvertChromiumUrlMocked:
         with sync_client.chromium.url_to_pdf() as route:
             route.url(webserver_docker_internal_url).skip_network_almost_idle(skip=True).run()
         verify_stream_contains(httpx_mock.get_request(), "skipNetworkAlmostIdleEvent", "true")
+
+    def test_generate_tagged_pdf(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).generate_tagged_pdf(generate=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "generateTaggedPdf", "true")
+
+    def test_string_header(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).string_header("<html><body>Header</body></html>").run()
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        assert any(b'filename="header.html"' in part for part in parts)
+
+    def test_string_footer(
+        self,
+        sync_client: GotenbergClient,
+        webserver_docker_internal_url: str,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.chromium.url_to_pdf() as route:
+            route.url(webserver_docker_internal_url).string_footer("<html><body>Footer</body></html>").run()
+        request = httpx_mock.get_request()
+        boundary = request.headers["Content-Type"].split("boundary=")[1]
+        parts = request.content.split(f"--{boundary}".encode())
+        assert any(b'filename="footer.html"' in part for part in parts)

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -299,3 +299,36 @@ class TestLibreOfficeMocked:
         with sync_client.libre_office.to_pdf() as route:
             route.convert(docx_sample_file).user_password("secret").run()
         verify_stream_contains(httpx_mock.get_request(), "userPassword", "secret")
+
+    def test_export_placeholders(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).export_placeholders(export_placeholders=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "exportPlaceholders", "true")
+
+    def test_native_watermark_text(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_watermark_text("CONFIDENTIAL").run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeWatermarkText", "CONFIDENTIAL")
+
+    def test_native_tiled_watermark_text(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_tiled_watermark_text("DRAFT").run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeTiledWatermarkText", "DRAFT")

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -336,6 +336,50 @@ class TestLibreOfficeMocked:
             route.convert(docx_sample_file).native_tiled_watermark_text("DRAFT").run()
         verify_stream_contains(httpx_mock.get_request(), "nativeTiledWatermarkText", "DRAFT")
 
+    def test_native_watermark_color(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_watermark_color(0x808080).run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeWatermarkColor", str(0x808080))
+
+    def test_native_watermark_font_height(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_watermark_font_height(36).run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeWatermarkFontHeight", "36")
+
+    def test_native_watermark_rotate_angle(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_watermark_rotate_angle(450).run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeWatermarkRotateAngle", "450")
+
+    def test_native_watermark_font_name(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).native_watermark_font_name("Arial").run()
+        verify_stream_contains(httpx_mock.get_request(), "nativeWatermarkFontName", "Arial")
+
     def test_initial_page(
         self,
         sync_client: GotenbergClient,

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -332,3 +332,25 @@ class TestLibreOfficeMocked:
         with sync_client.libre_office.to_pdf() as route:
             route.convert(docx_sample_file).native_tiled_watermark_text("DRAFT").run()
         verify_stream_contains(httpx_mock.get_request(), "nativeTiledWatermarkText", "DRAFT")
+
+    def test_initial_page(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).initial_page(3).run()
+        verify_stream_contains(httpx_mock.get_request(), "initialPage", "3")
+
+    def test_hide_viewer_menubar(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).hide_viewer_menubar(hide=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "hideViewerMenubar", "true")

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -13,6 +13,9 @@ from pytest_httpx import HTTPXMock
 from gotenberg_client import GotenbergClient
 from gotenberg_client import SingleFileResponse
 from gotenberg_client import ZipFileResponse
+from gotenberg_client._libreoffice.mixins import InitialView
+from gotenberg_client._libreoffice.mixins import MagnificationOption
+from gotenberg_client._libreoffice.mixins import PageLayout
 from gotenberg_client._libreoffice.routes import AsyncOfficeDocumentToPdfRoute
 from gotenberg_client._utils import guess_mime_type_stdlib
 from gotenberg_client.options import PageOrientation
@@ -354,3 +357,146 @@ class TestLibreOfficeMocked:
         with sync_client.libre_office.to_pdf() as route:
             route.convert(docx_sample_file).hide_viewer_menubar(hide=True).run()
         verify_stream_contains(httpx_mock.get_request(), "hideViewerMenubar", "true")
+
+    def test_initial_view(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).initial_view(InitialView.OUTLINE).run()
+        verify_stream_contains(httpx_mock.get_request(), "initialView", "1")
+
+    def test_magnification(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).magnification(MagnificationOption.FIT_WIDTH).run()
+        verify_stream_contains(httpx_mock.get_request(), "magnification", "2")
+
+    def test_zoom(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).zoom(50).run()
+        verify_stream_contains(httpx_mock.get_request(), "zoom", "50")
+
+    def test_page_layout(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).page_layout(PageLayout.CONTINUOUS).run()
+        verify_stream_contains(httpx_mock.get_request(), "pageLayout", "2")
+
+    def test_first_page_on_left(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).first_page_on_left(first_page_on_left=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "firstPageOnLeft", "true")
+
+    def test_resize_window_to_initial_page(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).resize_window_to_initial_page(resize=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "resizeWindowToInitialPage", "true")
+
+    def test_center_window(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).center_window(center=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "centerWindow", "true")
+
+    def test_open_in_full_screen_mode(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).open_in_full_screen_mode(full_screen=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "openInFullScreenMode", "true")
+
+    def test_display_pdf_document_title(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).display_pdf_document_title(display_title=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "displayPDFDocumentTitle", "true")
+
+    def test_hide_viewer_toolbar(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).hide_viewer_toolbar(hide=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "hideViewerToolbar", "true")
+
+    def test_hide_viewer_window_controls(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).hide_viewer_window_controls(hide=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "hideViewerWindowControls", "true")
+
+    def test_use_transition_effects(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).use_transition_effects(use=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "useTransitionEffects", "true")
+
+    def test_open_bookmark_levels(
+        self,
+        sync_client: GotenbergClient,
+        docx_sample_file: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.libre_office.to_pdf() as route:
+            route.convert(docx_sample_file).open_bookmark_levels(-1).run()
+        verify_stream_contains(httpx_mock.get_request(), "openBookmarkLevels", "-1")

--- a/tests/test_convert_libre_office.py
+++ b/tests/test_convert_libre_office.py
@@ -13,11 +13,11 @@ from pytest_httpx import HTTPXMock
 from gotenberg_client import GotenbergClient
 from gotenberg_client import SingleFileResponse
 from gotenberg_client import ZipFileResponse
-from gotenberg_client._libreoffice.mixins import InitialView
-from gotenberg_client._libreoffice.mixins import MagnificationOption
-from gotenberg_client._libreoffice.mixins import PageLayout
 from gotenberg_client._libreoffice.routes import AsyncOfficeDocumentToPdfRoute
 from gotenberg_client._utils import guess_mime_type_stdlib
+from gotenberg_client.options import InitialView
+from gotenberg_client.options import MagnificationOption
+from gotenberg_client.options import PageLayout
 from gotenberg_client.options import PageOrientation
 from gotenberg_client.options import PdfAFormat
 from gotenberg_client.options import WatermarkStampSource

--- a/tests/test_convert_pdf_a.py
+++ b/tests/test_convert_pdf_a.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2023-present Trenton H <rda0128ou@mozmail.com>
 #
 # SPDX-License-Identifier: MPL-2.0
+from http import HTTPStatus
 from pathlib import Path
 
 import pikepdf
 import pytest
-from httpx import codes
 
 from gotenberg_client import GotenbergClient
 from gotenberg_client._pdfa_ua.routes import AsyncConvertToArchiveFormatRoute
@@ -28,7 +28,7 @@ class TestPdfAConvert:
         with sync_client.pdf_convert.to_pdfa() as route:
             resp = route.convert(pdf_sample_one_file).pdf_format(gt_format).run_with_retry()
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -51,7 +51,7 @@ class TestPdfAConvert:
         with sync_client.pdf_convert.to_pdfa() as route:
             resp = route.convert_files([pdf_sample_one_file, other_test_file]).pdf_format(gt_format).run_with_retry()
 
-            assert resp.status_code == codes.OK
+            assert resp.status_code == HTTPStatus.OK
             assert "Content-Type" in resp.headers
             assert resp.headers["Content-Type"] == "application/zip"
 
@@ -65,7 +65,7 @@ class TestPdfAConvert:
                 route.convert(pdf_sample_one_file).pdf_format(PdfAFormat.A2b).enable_universal_access().run_with_retry()
             )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -82,7 +82,7 @@ class TestPdfAConvert:
                 .run_with_retry()
             )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -100,6 +100,6 @@ class TestPdfAConvertAsync:
             .run_with_retry()
         )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -121,3 +121,26 @@ class TestMergePdfsMocked:
         with sync_client.merge.merge() as route:
             route.merge([sample_directory / "sample1.pdf"]).user_password("pw").run()
         verify_stream_contains(httpx_mock.get_request(), "userPassword", "pw")
+
+    def test_merge_auto_index_bookmarks(
+        self,
+        sync_client: GotenbergClient,
+        sample_directory: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        with sync_client.merge.merge() as route:
+            route.merge([sample_directory / "sample1.pdf"]).auto_index_bookmarks(enable=True).run()
+        verify_stream_contains(httpx_mock.get_request(), "autoIndexBookmarks", "true")
+
+    def test_merge_bookmarks(
+        self,
+        sync_client: GotenbergClient,
+        sample_directory: Path,
+        httpx_mock: HTTPXMock,
+    ):
+        httpx_mock.add_response(method="POST")
+        bookmarks = [{"title": "Section 1", "page": 1}]
+        with sync_client.merge.merge() as route:
+            route.merge([sample_directory / "sample1.pdf"]).merge_bookmarks(bookmarks).run()
+        verify_stream_contains(httpx_mock.get_request(), "bookmarks", "Section 1")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2023-present Trenton H <rda0128ou@mozmail.com>
 #
 # SPDX-License-Identifier: MPL-2.0
+from http import HTTPStatus
 from pathlib import Path
 
 import pikepdf
 import pytest
-from httpx import codes
 from pytest_httpx import HTTPXMock
 
 from gotenberg_client import GotenbergClient
@@ -37,7 +37,7 @@ class TestMergePdfs:
                 )
                 .run_with_retry()
             )
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -59,7 +59,7 @@ class TestMergePdfs:
                 [sample_directory / "z_first_merge.pdf", sample_directory / "a_merge_second.pdf"],
             ).run_with_retry()
 
-            assert resp.status_code == codes.OK
+            assert resp.status_code == HTTPStatus.OK
             assert "Content-Type" in resp.headers
             assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -85,7 +85,7 @@ class TestMergePdfsAsync:
             [sample_directory / "z_first_merge.pdf", sample_directory / "a_merge_second.pdf"],
         ).run_with_retry()
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from http import HTTPStatus
 from pathlib import Path
 
 import pikepdf
 import pytest
-from httpx import codes
 
 from gotenberg_client import GotenbergClient
 from gotenberg_client import InvalidKeywordError
@@ -60,7 +60,7 @@ class TestPdfMetadataOnConvert:
                 .run_with_retry()
             )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -106,7 +106,7 @@ class TestPdfMetadataOnConvert:
                 .run_with_retry()
             )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -138,7 +138,7 @@ class TestPdfMetadataOnConvert:
                 .run_with_retry()
             )
 
-        assert resp.status_code == codes.OK
+        assert resp.status_code == HTTPStatus.OK
         assert "Content-Type" in resp.headers
         assert resp.headers["Content-Type"] == "application/pdf"
 
@@ -270,7 +270,7 @@ class TestPdfMetadataWriteExisting:
             sync_write_pdf_metadata_route.write_files([pdf_sample_one_file]).metadata(author=author).run_with_retry()
         )
 
-        assert response.status_code == codes.OK
+        assert response.status_code == HTTPStatus.OK
         assert "Content-Type" in response.headers
         assert response.headers["Content-Type"] == "application/pdf"
 
@@ -316,7 +316,7 @@ class TestPdfMetadataRoundTrip:
                 .run_with_retry()
             )
 
-        assert write_response.status_code == codes.OK
+        assert write_response.status_code == HTTPStatus.OK
         assert write_response.headers["Content-Type"] == "application/pdf"
         written_pdf = tmp_path / "round_trip.pdf"
         write_response.to_file(written_pdf)


### PR DESCRIPTION
Various route fields has either been added in new versions or were never implemented here.  Mostly in Chromium routes or LibreOffice routes, with a few in merge.